### PR TITLE
Add travis validation for code snippets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,6 @@
 script:
-    - |
-      set -eu
-
-      function compile {
-          PYTHONPATH=mbed-os python mbed-os/tools/make.py -t GCC_ARM -m K64F \
-              --source=. --build=BUILD/K64F/GCC_ARM
-      }
-
-      for f in $(find -name '*.md')
-      do
-          # find all c++ snippets and compile
-          for l in $(sed -n '/``` *\(cpp\|c++\)\>/=' $f)
-          do
-              sed -n $l',/```/{/```/d;p}' $f > main.cpp
-              compile
-              rm main.cpp
-          done
-
-          # find all c snippets and compile
-          for l in $(sed -n '/``` *c\>/=' $f)
-          do
-              sed -n $l',/```/{/```/d;p}' $f > main.c
-              compile
-              rm main.c
-          done
-      done
-    set -eu
-    set -o pipefail
+  - |
+    set -eo pipefail
 
     mkdir -p BUILD
     echo '*' > BUILD/.mbedignore
@@ -38,19 +12,16 @@ script:
     function compile {
         if [ "$1" != "NO" ]
         then
-            PYTHONPATH=mbed-os python mbed-os/tools/make.py -t GCC_ARM \
-                -m ${1:-ARCH_PRO} --source=. \
-                --build=BUILD/${1:-ARCH_PRO}/GCC_ARM \
-                | sed '/\(error\|warning\)/I!d'
+            PYTHONPATH=mbed-os python mbed-os/tools/make.py -t GCC_ARM -m ${1:-ARCH_PRO} --source=. --build=BUILD/${1:-ARCH_PRO}/GCC_ARM | sed '/\(error\|warning\)/I!d'
         fi
     }
      
-    for f in $(find -name '*.md')
+    for f in $(find -name mbed-os -prune -o -name '*.md' -print)
     do
         # compile c++ snippets
         for l in $(sed -n '/``` *\(cpp\|c++\)\($\| \+\)/I=' $f)
         do
-            echo "Building $f:$l ..."
+            echo "Validating cpp $f:$l ..."
             sed -n $l',/```/{/```/d;p}' $f > main.cpp
             compile "$(sed -n $l's/ *``` *\(cpp\|c++\)\($\| \+\)//Ip' $f)"
             rm main.cpp
@@ -59,10 +30,27 @@ script:
         # compile c snippets
         for l in $(sed -n '/``` *c\($\| \+\)/I=' $f)
         do
-            echo "Building $f:$l ..."
+            echo "Validating c $f:$l ..."
             sed -n $l',/```/{/```/d;p}' $f > main.c
             compile "$(sed -n $l's/ *``` *c\($\| \+\)//Ip' $f)"
             rm main.c
+        done
+
+        # validate json snippets
+        for l in $(sed -n '/``` *json\($\| \+\)/I=' $f)
+        do
+            echo "Validating json $f:$l ..."
+            sed -n $l',/```/{/```/d;p}' $f > main.json
+            if [ "$(sed -n $l's/ *``` *json\($\| \+\)//Ip' $f)" != "NO" ]
+            then
+                if sed -n '/ *"/q0;/ *[^ ]/q1' main.json
+                then
+                    (echo "{" ; cat main.json ; echo "}") | python -m json.tool > /dev/null
+                else
+                    cat main.json | python -m json.tool > /dev/null
+                fi
+            fi
+            rm main.json
         done
     done
 
@@ -74,4 +62,4 @@ install:
       # Get dependencies
     - git clone https://github.com/armmbed/mbed-os.git
       # Install python dependencies
-    - pip install -r mbed-os/requirements.txt
+    - pip install --user -r mbed-os/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,77 @@
+script:
+    - |
+      set -eu
+
+      function compile {
+          PYTHONPATH=mbed-os python mbed-os/tools/make.py -t GCC_ARM -m K64F \
+              --source=. --build=BUILD/K64F/GCC_ARM
+      }
+
+      for f in $(find -name '*.md')
+      do
+          # find all c++ snippets and compile
+          for l in $(sed -n '/``` *\(cpp\|c++\)\>/=' $f)
+          do
+              sed -n $l',/```/{/```/d;p}' $f > main.cpp
+              compile
+              rm main.cpp
+          done
+
+          # find all c snippets and compile
+          for l in $(sed -n '/``` *c\>/=' $f)
+          do
+              sed -n $l',/```/{/```/d;p}' $f > main.c
+              compile
+              rm main.c
+          done
+      done
+    set -eu
+    set -o pipefail
+
+    mkdir -p BUILD
+    echo '*' > BUILD/.mbedignore
+    cat > fake_main.c <<MAIN
+    #include "mbed_toolchain.h"
+    MBED_WEAK void main(void) {}
+    MAIN
+
+    function compile {
+        if [ "$1" != "NO" ]
+        then
+            PYTHONPATH=mbed-os python mbed-os/tools/make.py -t GCC_ARM \
+                -m ${1:-ARCH_PRO} --source=. \
+                --build=BUILD/${1:-ARCH_PRO}/GCC_ARM \
+                | sed '/\(error\|warning\)/I!d'
+        fi
+    }
+     
+    for f in $(find -name '*.md')
+    do
+        # compile c++ snippets
+        for l in $(sed -n '/``` *\(cpp\|c++\)\($\| \+\)/I=' $f)
+        do
+            echo "Building $f:$l ..."
+            sed -n $l',/```/{/```/d;p}' $f > main.cpp
+            compile "$(sed -n $l's/ *``` *\(cpp\|c++\)\($\| \+\)//Ip' $f)"
+            rm main.cpp
+        done
+        
+        # compile c snippets
+        for l in $(sed -n '/``` *c\($\| \+\)/I=' $f)
+        do
+            echo "Building $f:$l ..."
+            sed -n $l',/```/{/```/d;p}' $f > main.c
+            compile "$(sed -n $l's/ *``` *c\($\| \+\)//Ip' $f)"
+            rm main.c
+        done
+    done
+
+install:
+      # Get arm-none-eabi-gcc
+    - sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq gcc-arm-none-eabi --force-yes
+      # Get dependencies
+    - git clone https://github.com/armmbed/mbed-os.git
+      # Install python dependencies
+    - pip install -r mbed-os/requirements.txt

--- a/docs/contributing/code_style.md
+++ b/docs/contributing/code_style.md
@@ -34,7 +34,7 @@ Mbed OS follows the [K&R style](https://en.wikipedia.org/wiki/Indent_style#K.26R
 
 ##### Code sample
 
-```c
+```c NO
 static const PinMap PinMap_ADC[] = {
     {PTC2, ADC0_SE4b, 0},
     {NC , NC , 0}
@@ -43,6 +43,7 @@ static const PinMap PinMap_ADC[] = {
 uint32_t adc_function(analogin_t *obj, uint32_t options)
 {
     uint32_t instance = obj->adc >> ADC_INSTANCE_SHIFT;
+
     switch (options) {
         case 1:
             timeout = 6;
@@ -129,7 +130,7 @@ uint32_t adc_function(analogin_t *obj, uint32_t options)
 
 As an example:
 
-```c
+```cpp NO
 #define ADC_INSTANCE_SHIFT 8 
 
 class AnalogIn {

--- a/docs/contributing/tls_porting.md
+++ b/docs/contributing/tls_porting.md
@@ -55,7 +55,7 @@ You have to define a structure `trng_s` that holds all the information needed to
 
 To enable initializing and releasing the peripheral, you must implement the following functions:
 
-```C
+```c NO
 void trng_init(trng_t *obj);
 void trng_free(trng_t *obj);
 ```
@@ -64,7 +64,7 @@ void trng_free(trng_t *obj);
 
 The function `trng_get_bytes()` serves as the primary interface to the entropy source. It is expected to load the collected entropy to the buffer and is declared as follows:
 
-```C
+```c NO
 int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_length);
 ```
 
@@ -115,7 +115,7 @@ The NV seed entropy source needs to know how to retrieve and store the seed in n
 
 The relevant read/write functions have the following prototypes:
 
-``` C
+``` c NO
 int (*mbedtls_nv_seed_read)( unsigned char *buf, size_t buf_len );
 int (*mbedtls_nv_seed_write)( unsigned char *buf, size_t buf_len );
 ```

--- a/docs/refs/api/drivers/SPISlave.md
+++ b/docs/refs/api/drivers/SPISlave.md
@@ -15,7 +15,7 @@ Reply to a SPI master as slave:
 ```c++
 #include "mbed.h"
 
-SPISlave device(p5, p6, p7, p8); // mosi, miso, sclk, ssel
+SPISlave device(D9, D11, D12, D13); // mosi, miso, sclk, ssel
 
 int main() {
    device.reply(0x00);              // Prime SPI with first reply

--- a/docs/refs/how_to_document.md
+++ b/docs/refs/how_to_document.md
@@ -43,10 +43,12 @@ Another notable feature of the API documentation in the Mbed Online Compiler is 
 The documentation is created out of comment blocks in your code, usually located above declarations and definitions. Let's take the following example:
 
 ```c++
+#include <stdint.h>
+
 class HelloWorld {
 	public:
 		HelloWorld();
-		printIt(uint32_t delay = 0);
+		int printIt(uint32_t delay = 0);
 };
 ```
 
@@ -59,6 +61,8 @@ The most important thing about code documentation is explicitly telling the syst
 
 
 ```c++
+#include <stdint.h>
+
 /** My HelloWorld class.
 *  Used for printing "Hello World" on USB serial.
 */
@@ -68,13 +72,15 @@ class HelloWorld {
 		HelloWorld();
 
 		/** Print the text */
-		printIt(uint32_t delay = 0);
+		int printIt(uint32_t delay = 0);
 };
 ```
 
 You can also document single line comments, by starting them with ``///`` or ``//!``:
 
 ```c++
+#include <stdint.h>
+
 //! My HelloWorld class. Used for printing "Hello World" on USB serial.
 class HelloWorld {
 	public:
@@ -82,7 +88,7 @@ class HelloWorld {
 	HelloWorld();
 
 	/// Print the text
-	printIt(uint32_t delay = 0);
+	int printIt(uint32_t delay = 0);
 };
 ```
 
@@ -109,6 +115,8 @@ Doxygen accepts reserved words prefixed with ``\`` or ``@``. Some of the commonl
 Here is an example of advanced documentation:
 
 ```c++
+#include <stdint.h>
+
 /** My HelloWorld class.
 *  Used for printing "Hello World" on USB serial.
 *
@@ -137,7 +145,7 @@ class HelloWorld {
 		*   1 on success,
 		*   0 on serial error
 		*/
-		printIt(uint32_t delay = 0);
+		int printIt(uint32_t delay = 0);
 };
 ```
 

--- a/docs/tools/testing/utest.md
+++ b/docs/tools/testing/utest.md
@@ -24,7 +24,7 @@ The order of handler execution is:
 This example showcases functionality and proper integration with the [Greentea testing automation framework](advanced/greentea.md), while making use of the [unity test macros](https://github.com/ARMmbed/mbed-os/tree/master/features/frameworks/unity):
 
 ```cpp
-#include "mbed-drivers/test_env.h"
+#include "greentea-client/test_env.h"
 #include "utest/utest.h"
 #include "unity/unity.h"
 
@@ -48,6 +48,7 @@ control_t test_repeats(const size_t call_count) {
     return (call_count < 2) ? CaseRepeatAll : CaseNext;
 }
 
+Timeout timeout;
 void test_callback_validate() {
     // You may also use assertions here
     TEST_ASSERT_EQUAL_PTR(0, 0);
@@ -57,7 +58,7 @@ void test_callback_validate() {
 control_t test_asynchronous() {
     TEST_ASSERT_TRUE_MESSAGE(true, "(true == false) o_O");
     // Set up a callback in the future. This may also be an interrupt
-    minar::Scheduler::postCallback(test_callback_validate).delay(minar::milliseconds(100));
+    timeout.attach_us(test_callback_validate, 100000);
     // Set a 200 ms timeout starting from now
     return CaseTimeout(200);
 }
@@ -68,7 +69,7 @@ control_t test_asynchronous_timeout(const size_t call_count) {
     // but automatically repeat only this handler on timeout
     if (call_count >= 5) {
         // but after the 5th call, the callback finally gets validated
-        minar::Scheduler::postCallback(test_callback_validate).delay(minar::milliseconds(100));
+        timeout.attach_us(test_callback_validate, 100000);
     }
     return CaseRepeatHandlerOnTimeout(200);
 }
@@ -246,7 +247,7 @@ These default handlers are called when you have not overridden a custom handler,
 
 You can specify which default handlers you want to use when wrapping your test cases in the `Specification` class:
 
-```cpp
+```cpp NO
 // Declare your test specification with a custom setup handler
 // and set the default handlers to the predefined “greentea continue” behavior
 Specification specification(greentea_setup, cases, greentea_continue_handlers);
@@ -316,7 +317,7 @@ Please see [the doxygen documentation for implementation details](utest/schedule
 
 Here is the most [basic scheduler implementation without any asynchronous support](test/minimal_scheduler/main.cpp). Note that this does not require any hardware support at all, but you cannot use timeouts in your test cases.
 
-```cpp
+```cpp NO
 volatile utest_v1_harness_callback_t minimal_callback;
 
 static void* utest_minimal_post(const utest_v1_harness_callback_t callback, const uint32_t delay_ms) {
@@ -352,7 +353,7 @@ void main() // or whatever your custom entry point is
 
 Here is the [complete scheduler implementation with any asynchronous support](test/minimal_scheduler_async/main.cpp). Note that this does require at least a hardware timer. This example uses `mbed-hal/us_ticker`. Note that you must not execute the callback in the timer interrupt context, but in the main loop context.
 
-```cpp
+```cpp NO
 volatile utest_v1_harness_callback_t minimal_callback;
 volatile utest_v1_harness_callback_t ticker_callback;
 const ticker_data_t *ticker_data;

--- a/docs/tutorials/cellular_porting_guide.md
+++ b/docs/tutorials/cellular_porting_guide.md
@@ -44,7 +44,7 @@ No matter your setup, Mbed OS provides ample framework. You can list common infr
 
 > Only valid for onboard modem types. In other words, **Case 3** is applicable. A hardware abstraction layer is between a cellular modem and an Mbed OS cellular driver. This API provides basic framework for initializing and uninitializing hardware, as well as turning the modem on or off. For example:
 
-```C
+```C NO
 /** Sets the modem up for powering on
  *  modem_init() will be equivalent to plugging in the device, i.e.,
  *  attaching power or serial port.
@@ -57,13 +57,13 @@ void modem_init(modem_t *obj);
 
 > We have enhanced the existing `FileHandle` API to make it more usable for devices - it now supports nonblocking operation, SIGIO-style event notification and polling (see below). This makes a cellular interface implementation independent of underlying physical interface between the cellular modem and MCU, for example Serial UART, USB and so on.
 
-``` CPP
+``` CPP NO
 FileHandle _fh;
 ```
 
 > In case of a UART type of device, Mbed OS provides an implementation of serial device type `FileHandle` with software buffering.
 
-```CPP
+```CPP NO
 FileHandle * _fh = new UARTSerial(TX_PIN, RX_PIN, BAUDRATE);
 ```
 
@@ -73,7 +73,7 @@ FileHandle * _fh = new UARTSerial(TX_PIN, RX_PIN, BAUDRATE);
 
 > An AT command parser that takes in a file handle and subsequently reads and writes to the user provided file handle.
 
-```CPP
+```CPP NO
 ATCmdParser *_at = new ATCmdParser(_fh);
 ```
 
@@ -81,7 +81,7 @@ ATCmdParser *_at = new ATCmdParser(_fh);
 
 > A mechanism to multiplex input and output over a set of file handles (file descriptors). `poll()` examines every file handle provided for any events registered for that particular file handle.
 
-```CPP
+```CPP NO
 /**
 * Where fhs is an array of pollfh structs carrying FileHandle(s) and bit mask of events.
 * nhfs is the number of file handles.
@@ -94,7 +94,7 @@ int poll(pollfh fhs[], unsigned nfhs, int timeout);
 
 > Only valid when **Case 1** is applicable. This provides an interface for cellular drivers to underlying framework provided by the network stack. This in effect means that the driver itself does not depend on a certain network stack. In other words, it talks to any network stack providing this standard PPP interface. For example:
 
-```CPP
+```CPP NO
 /** Connect to a PPP pipe
  *
  *  @param stream       Pointer to a device type file handle (descriptor)
@@ -144,7 +144,7 @@ For example,
 ```
 2. **Use standard pin names**. A standard naming conventions for pin names is required for standard modem pins in your target's **_'targets/TARGET_FAMILY/YOUR_TARGET/PinNames.h'_**. An example is shown below for full UART capable modem. If any of these pins is not connected physically, mark it **_'NC'_**. Also indicate pin polarity.
 
-```C
+```C NO
 typedef enum {
 
 	MDMTXD = P0_15, // Transmit Data

--- a/docs/tutorials/cellular_porting_guide.md
+++ b/docs/tutorials/cellular_porting_guide.md
@@ -140,7 +140,7 @@ For example,
         "inherits": ["TargetBond"],
         "device_has": ["ETHERNET", "SPI"],
         "device_name": "JamesBond"
-    },
+    }
 ```
 2. **Use standard pin names**. A standard naming conventions for pin names is required for standard modem pins in your target's **_'targets/TARGET_FAMILY/YOUR_TARGET/PinNames.h'_**. An example is shown below for full UART capable modem. If any of these pins is not connected physically, mark it **_'NC'_**. Also indicate pin polarity.
 

--- a/docs/tutorials/connectivity/cellular_tcp.md
+++ b/docs/tutorials/connectivity/cellular_tcp.md
@@ -2,7 +2,7 @@
 
 This example opens a TCP socket with an echo server and undergoes a TCP transaction. Connection logic is the same as in the previous example.
 
-```cpp
+```cpp NO
 #include "mbed.h"
 #include "UDPSocket.h"
 #include "OnboardCellularInterface.h"

--- a/docs/tutorials/debug/debug_with_printf.md
+++ b/docs/tutorials/debug/debug_with_printf.md
@@ -154,7 +154,7 @@ You can learn more on [Wikipedia](http://en.wikipedia.org/wiki/Printf_format_str
 
 If you run this code, you may receive an unpleasant surprise:
 
-```cpp
+```cpp K64F
 #include "mbed.h"
 
 DigitalOut led(LED1);
@@ -221,7 +221,7 @@ enum {
 
 extern unsigned traceLevel;
 
-...
+// ...
 
 // Our first macro prints if the trace level we selected
 // is TRACE_LEVEL_DEBUG or above.
@@ -269,13 +269,17 @@ To avoid pushing during the operation’s run, use `sprintf()` to write the log 
 This is an example implementation of a ring buffer, which wraps `printf()` using a macro called `xprintf()`. Debug messages accumulated using `xprintf()` can be read circularly starting from `ringBufferTail` and wrapping around (`ringBufferTail` + `HALF_BUFFER_SIZE`). An overwrite by the most recently appended message may garble the first message:
 
 ```c
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
 #define BUFFER_SIZE 512 /* You need to choose a suitable value here. */
 #define HALF_BUFFER_SIZE (BUFFER_SIZE >> 1)
 
 /* Here's one way of allocating the ring buffer. */
 char ringBuffer[BUFFER_SIZE];
 char *ringBufferStart = ringBuffer;
-char *ringBufferTail  = ringBuffer;
+char *ringBufferTail  = ringBuffer;
 
 void xprintf(const char *format, ...)
 {

--- a/docs/tutorials/patterns/design_guidelines.md
+++ b/docs/tutorials/patterns/design_guidelines.md
@@ -152,7 +152,7 @@ A general module can be split into two APIs, the frontend (or user API) and the 
 
 - Each function and class in a module should provide a doxygen comment that documents the function and each argument and return value:
 
-    ``` cpp
+    ``` cpp NO
     /** Wait until a Mutex becomes available.
      *
      * @param   millisec  timeout value or 0 in case of no time-out. (default: osWaitForever)

--- a/docs/tutorials/serial/serial_communication.md
+++ b/docs/tutorials/serial/serial_communication.md
@@ -17,7 +17,7 @@ This allows you to:
 This program prints a "Hello World" message that you can view on a [terminal application](#terminal-applications). Communication over the USB serial port uses the standard serial interface. Specify the internal (USBTX, USBRX) pins to connect to the serial port routed over USB:
 
 
-```c
+```cpp
 #include "mbed.h"
 
 Serial pc(USBTX, USBRX); // tx, rx
@@ -75,7 +75,7 @@ If you're not sure how to build these examples and run them on your board, pleas
 
 ##### Echo back characters you type
 
-```c
+```cpp
 #include "mbed.h"
 
 Serial pc(USBTX, USBRX);
@@ -94,7 +94,7 @@ int main() {
 
 <span class="images">![](images/NUCLEOF401RE.png)<span>The pin map of the NUCLEO-F401RE shows LED1 on the Pwm pin.</span></span>
 
-```c
+```cpp
 #include "mbed.h"
 
 Serial pc(USBTX, USBRX); // tx, rx
@@ -121,7 +121,7 @@ int main() {
 
 ##### Pass characters in both directions
 
-```c
+```cpp
 #include "mbed.h"
 
 Serial pc(USBTX, USBRX);
@@ -149,7 +149,7 @@ Tie pins together to see characters echoed back.
 
 By default, the C ``stdin``, ``stdout`` and ``stderr file`` handles map to the PC serial connection:
 
-```c
+```cpp
 #include "mbed.h"
 
 int main() {
@@ -160,7 +160,7 @@ int main() {
 
 ##### Read to a buffer
 
-```c
+```cpp
 #include "mbed.h"
 
 DigitalOut myled(LED1);


### PR DESCRIPTION
Added a little script in travis to compile/validate any c/c++/json code snippets.

There were a few hickups with target specific blobs, so I also parse out an optional target to use for compilation (defaults to LPC1768). Or, you can simply put NO to opt out of validation.

cc @AnotherButler, @mbartling 