### PR TITLE
Rename LOWPOWERTIMER to LPTICKER

### DIFF
--- a/docs/reference/contributing/target/lp_ticker.md
+++ b/docs/reference/contributing/target/lp_ticker.md
@@ -38,7 +38,7 @@ Be careful around these common trouble areas when implementing this API:
 
 Some low power tickers require multiple low power clock cycles for the compare value that `ticker_set_interrupt` sets to take effect. Further complicating this issue, a new compare value typically cannot be set until the first has taken effect. Because of this, when you make back-to-back calls to `ticker_set_interrupt` without a delay, the second call blocks and violates the above requirement that `ticker_set_interrupt` completes in 20us.
 
-To meet this timing requirement, targets that have this synchronization delay must set `LOWPOWERTIMER_DELAY_TICKS` to the number of low power clock cycles it takes for a call to `ticker_set_interrupt` to take effect. When the targets set this value, the timer code prevents `lp_ticker_set_interrupt` from being called twice within that number of clock cycles. It does this by using the microsecond time to schedule the write to happen at a future date.
+To meet this timing requirement, targets that have this synchronization delay must set `LPTICKER_DELAY_TICKS` to the number of low power clock cycles it takes for a call to `ticker_set_interrupt` to take effect. When the targets set this value, the timer code prevents `lp_ticker_set_interrupt` from being called twice within that number of clock cycles. It does this by using the microsecond time to schedule the write to happen at a future date.
 
 ### Dependencies
 

--- a/docs/reference/contributing/target/target.md
+++ b/docs/reference/contributing/target/target.md
@@ -46,7 +46,8 @@ CAN              |   can_api.h
 EMAC             |   emac_api.h
 INTERRUPTIN      |   gpio_irq_api.h
 I2C I2CSLAVE     |   i2c_api.h
-LOWPOWERTIMER    |   lp_ticker_api.h
+LPTICKER         |   lp_ticker_api.h
+LPTICKER         |   lp_ticker_api.h
 PORT_IN PORT_OUT |   port_api.h
 PWMOUT           |   pwmout_api.h
 RTC              |   rtc_api.h

--- a/docs/tools/mbed_targets.md
+++ b/docs/tools/mbed_targets.md
@@ -351,7 +351,7 @@ For each of these target roles, some restrictions are in place:
   - `I2CSLAVE`.
   - `I2C_ASYNCH`.
   - `INTERRUPTIN`.
-  - `LOWPOWERTIMER`.
+  - `LPTICKER`.
   - `PORTIN`.
   - `PORTINOUT`.
   - `PORTOUT`.


### PR DESCRIPTION
Update the name in the docs to reflect the code.