### PR TITLE
Move Serial example 3 to RawSerial

### DIFF
--- a/docs/reference/api/drivers/RawSerial.md
+++ b/docs/reference/api/drivers/RawSerial.md
@@ -40,7 +40,7 @@ Write a message to a device at a baud rate of 19200.
 
 Attach a function to call during the generation of serial interrupts. This function defaults to interrupt on an RX pin.
 
-[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/Serial_ex_3/)](https://os.mbed.com/teams/mbed_example/code/Serial_ex_3/file/4ab47f33a1ae/main.cpp)
+[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/RawSerial_ex_2/)](https://os.mbed.com/teams/mbed_example/code/RawSerial_ex_2/file/3ad999bfc3c4/main.cpp/)
 
 #### Mbed OS example
 

--- a/docs/reference/api/drivers/RawSerial.md
+++ b/docs/reference/api/drivers/RawSerial.md
@@ -36,6 +36,12 @@ Write a message to a device at a baud rate of 19200.
 
 [![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/RawSerial_ex_1/)](https://os.mbed.com/teams/mbed_example/code/RawSerial_ex_1/file/6a0d9cb21969/main.cpp)
 
+#### Example two
+
+Attach a function to call during the generation of serial interrupts. This function defaults to interrupt on an RX pin.
+
+[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/Serial_ex_3/)](https://os.mbed.com/teams/mbed_example/code/Serial_ex_3/file/4ab47f33a1ae/main.cpp)
+
 #### Mbed OS example
 
 Common use cases for RawSerial are IRQ heavy UART operations, such as the [ATParser](https://github.com/ARMmbed/ATParser/blob/3209400df676cbf0183a5894f648c71727602d30/BufferedSerial/BufferedSerial.cpp#L29) in the ESP8266 driver. This driver uses UART on user supplied pins to communicate with the offchip ESP8266 module.

--- a/docs/reference/api/drivers/Serial.md
+++ b/docs/reference/api/drivers/Serial.md
@@ -39,12 +39,6 @@ Provide a serial pass-through between the PC and an external UART.
 
 [![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/Serial_ex_2/)](https://os.mbed.com/teams/mbed_example/code/Serial_ex_2/file/8d318218bac1/main.cpp)
 
-#### Example three
-
-Attach a function to call during the generation of serial interrupts. This function defaults to interrupt on an RX pin.
-
-[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/Serial_ex_3/)](https://os.mbed.com/teams/mbed_example/code/Serial_ex_3/file/4ab47f33a1ae/main.cpp)
-
 ### Related content
 
 - [Serial](/docs/development/introduction/glossary.html) glossary entry.


### PR DESCRIPTION
[Example three in the Serial API doc](https://os.mbed.com/docs/latest/reference/serial.html#example-three) attaches an interrupt to the Serial `pc` object, and inside the callback function `getc()` and `putc()` are used. As of the latest version of Mbed OS, both of these functions use mutex locks which are not allowed in ISR context, and create the following error at runtime:

```
++ MbedOS Error Info ++
Error Status: 0x80010133 Code: 307 Module: 1
Error Message: Mutex: 0x20000F1C, Not allowed in ISR context
Location: 0x1002B29
Error Value: 0x20000F1C
Current Thread: Id: 0x20002850 Entry: 0x10040C9 StackSize: 0x1000 StackMem: 0x20001810 SP: 0x2003FE50 
-- MbedOS Error Info --
```

In order to use `getc()` and `putc()` in ISR context with a serial interrupt, you need to use a [`RawSerial`](https://os.mbed.com/docs/latest/reference/rawserial.html) object.

If these changes get approved, I can either make a new example for RawSerial or update the existing example 3 for Serial here: https://os.mbed.com/teams/mbed_example/code/Serial_ex_3/