### PR TITLE
Update mbed_targets.md

### DIFF
--- a/docs/tools/mbed_targets.md
+++ b/docs/tools/mbed_targets.md
@@ -1,6 +1,6 @@
 ## Adding and configuring targets
 
-Arm Mbed uses JSON as a description language for its build targets. You can find the JSON description of Mbed targets in `targets/targets.json` and in `custom_targets.json` in the root of a project directory. When you add new targets with `custom_targets.json`, they are added to the list of available targets.
+Arm Mbed uses JSON as a description language for its build targets. You can find the JSON description of Mbed targets in `targets/targets.json` and in `extra_targets.json` in the root of a project directory. When you add new targets with `extra_targets.json`, they are added to the list of available targets.
 
 <span class="notes">**Note:** The Online Compiler does not support this functionality. You need to use [Mbed CLI](/docs/v5.7/tools/arm-mbed-cli.html) to take your code offline.</span>
 


### PR DESCRIPTION
The file the CLI is looking for is "extra_targets.json," not custom_targets.json ( I think an older version of mbed CLI used custom_targets.json )  I just tried this at the command line and confirmed this.  Also, this PR talks about extra_targets https://github.com/ARMmbed/mbed-os/pull/4103