### PR TITLE
Add note about where CLI looks for custom_targets.json

### DIFF
--- a/docs/tools/mbed_targets.md
+++ b/docs/tools/mbed_targets.md
@@ -1,6 +1,6 @@
 ## Adding and configuring targets
 
-Arm Mbed uses JSON as a description language for its build targets. You can find the JSON description of Mbed targets in `targets/targets.json` and in `custom_targets.json` in the root of a project directory. When you add new targets with `custom_targets.json`, they are added to the list of available targets.
+Arm Mbed uses JSON as a description language for its build targets. You can find the JSON description of Mbed targets in `targets/targets.json` and in `custom_targets.json` in the root of a project directory.  If you provide a source directory via the "--source" switch, then mbed will look for custom_targets.json in that directory instead. When you add new targets with `custom_targets.json`, they are added to the list of available targets.
 
 <span class="notes">**Note:** The Online Compiler does not support this functionality. You need to use [Mbed CLI](/docs/v5.7/tools/arm-mbed-cli.html) to take your code offline.</span>
 

--- a/docs/tools/mbed_targets.md
+++ b/docs/tools/mbed_targets.md
@@ -1,6 +1,6 @@
 ## Adding and configuring targets
 
-Arm Mbed uses JSON as a description language for its build targets. You can find the JSON description of Mbed targets in `targets/targets.json` and in `custom_targets.json` in the root of a project directory.  If you provide a source directory via the "--source" switch, then mbed will look for custom_targets.json in that directory instead. When you add new targets with `custom_targets.json`, they are added to the list of available targets.
+Arm Mbed uses JSON as a description language for its build targets. You can find the JSON description of Mbed targets in `targets/targets.json` and in `custom_targets.json` in the root of a project directory. If you provide a source directory using the `--source` switch, Mbed looks for `custom_targets.json` in that directory instead. When you add new targets with `custom_targets.json`, they are added to the list of available targets.
 
 <span class="notes">**Note:** The Online Compiler does not support this functionality. You need to use [Mbed CLI](/docs/v5.7/tools/arm-mbed-cli.html) to take your code offline.</span>
 


### PR DESCRIPTION
Please add a note about the --source switch affecting where cli expected custom_targets.json, something like I wrote here, as it's kind of a "gotcha"