### PR TITLE
FlashIAP driver link fix.

### DIFF
--- a/docs/reference/api/storage/storage.md
+++ b/docs/reference/api/storage/storage.md
@@ -90,7 +90,7 @@ Mbed OS has several block device implementations for common forms of storage:
 
 - [**HeapBlockDevice**](https://os.mbed.com/docs/development/reference/heapblockdevice.html) - Block device that simulates storage in RAM using the heap. Do not use the heap block device for storing data persistently because a power loss causes complete loss of data. Instead, use it for testing applications when a storage device is not available.
 
-- **FlashIAPBlockDevice** - Block device adapter for the [FlashIAP driver](https://os.mbed.com/docs/v5.8/reference/flash-iap.html), which provides an in application programming (IAP) interface for the MCU's internal flash memory.
+- **FlashIAPBlockDevice** - Block device adapter for the [FlashIAP driver](/docs/development/reference/flash-iap.html), which provides an in application programming (IAP) interface for the MCU's internal flash memory.
 
 #### Utility block devices
 


### PR DESCRIPTION
In general, all links seem to be the full paths. Shouldn't they be just the short forms, starting with /docs...?