### PR TITLE
Update testing section in the contributing docs

### DIFF
--- a/docs/reference/contributing/target/rtos.md
+++ b/docs/reference/contributing/target/rtos.md
@@ -32,7 +32,7 @@ Due to different use cases between Mbed OS and CMSIS, we modified the source cod
 
 ### Testing
 
-The Mbed OS provides a set of conformance tests for rtos configurations. You can use these tests to validate the correctness of your rtos porting. To run the rtos tests, use the following command:
+Mbed OS provides a set of conformance tests for RTOS configurations. You can use these tests to validate the correctness of your RTOS porting. To run the RTOS tests, use the following command:
 
 ```
 mbed test -t <toolchain> -m <target> -n "tests-mbedmicro-rtos-mbed*"

--- a/docs/reference/contributing/target/rtos.md
+++ b/docs/reference/contributing/target/rtos.md
@@ -29,3 +29,11 @@ Due to differences in the Mbed OS and CMSIS directory structure, you can't impor
 ### Modification
 
 Due to different use cases between Mbed OS and CMSIS, we modified the source code. We upstream our changes to the CMSIS repository, but in cases when they aren't compatible with CMSIS requirements, we maintain a small set of changes. We maintain changes as separate commits in `mbed-os`, and SHAs are in the `commit_sha` section of the `cmsis_importer.json` file.
+
+### Testing
+
+The Mbed OS provides a set of conformance tests for rtos configurations. You can use these tests to validate the correctness of your rtos porting. To run the rtos tests, use the following command:
+
+```
+mbed test -t <toolchain> -m <target> -n "tests-mbedmicro-rtos-mbed*"
+```

--- a/docs/reference/contributing/target/target.md
+++ b/docs/reference/contributing/target/target.md
@@ -55,3 +55,11 @@ SLEEP            |   sleep_api.h
 SPI SPISLAVE     |   spi_api.h
 TRNG             |   trng_api.h
 FLASH            |   flash_api.h
+
+### Testing
+
+The Mbed OS HAL provides a set of conformance tests for the Mbed OS HAL API. You can use these tests to validate the correctness of your implementation. To run the all of the Mbed OS HAL API tests, use the following command:
+
+```
+mbed test -t <toolchain> -m <target> -n mbed-os-tests-mbed_hal*
+```

--- a/docs/reference/contributing/target/target.md
+++ b/docs/reference/contributing/target/target.md
@@ -58,7 +58,7 @@ FLASH            |   flash_api.h
 
 ### Testing
 
-The Mbed OS HAL provides a set of conformance tests for the Mbed OS HAL API. You can use these tests to validate the correctness of your implementation. To run the all of the Mbed OS HAL API tests, use the following command:
+The Mbed OS HAL provides a set of conformance tests for the Mbed OS HAL APIs. You can use these tests to validate the correctness of your implementation. To run the all of the Mbed OS HAL API tests, use the following command:
 
 ```
 mbed test -t <toolchain> -m <target> -n mbed-os-tests-mbed_hal*

--- a/docs/reference/contributing/target/tickless.md
+++ b/docs/reference/contributing/target/tickless.md
@@ -13,7 +13,7 @@ To support tickless mode in Mbed OS, your target needs to meet two requirements:
 
 To enable tickless mode support in Mbed OS, you need to add the `MBED_TICKLESS` macro in the `macros` option of the target's section in the `targets.json` file.
 
-Targets supporting tickless mode override the default SysTick mechanism and use [RtosTimer](https://github.com/ARMmbed/mbed-os/blob/master/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp) implementation based on [low power ticker](https://github.com/ARMmbed/mbed-os/blob/master/drivers/LowPowerTicker.h). This change is necessary to avoid drift connected with using two different timers to measure time. It should be mostly invisible for users, except that users must not change the low power ticker interrupt handler when tickless mode is in use.
+Targets supporting tickless mode override the default SysTick mechanism and use [RtosTimer](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/classrtos_1_1_rtos_timer.html) implementation based on [low power ticker](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__lp__ticker.html). This change is necessary to avoid drift connected with using two different timers to measure time. It should be mostly invisible for users, except that users must not change the low power ticker interrupt handler when tickless mode is in use.
 
 #### Testing
 

--- a/docs/reference/contributing/target/tickless.md
+++ b/docs/reference/contributing/target/tickless.md
@@ -13,7 +13,7 @@ To support tickless mode in Mbed OS, your target needs to meet two requirements:
 
 To enable tickless mode support in Mbed OS, you need to add the `MBED_TICKLESS` macro in the `macros` option of the target's section in the `targets.json` file.
 
-Targets supporting tickless mode override the default SysTick mechanism and use [RtosTimer](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/classrtos_1_1_rtos_timer.html) implementation based on [low power ticker](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__lp__ticker.html). This change is necessary to avoid drift connected with using two different timers to measure time. It should be mostly invisible for users, except that users must not change the low power ticker interrupt handler when tickless mode is in use.
+Targets supporting tickless mode override the default SysTick mechanism and use the [RtosTimer](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/classrtos_1_1_rtos_timer.html) implementation based on the [low power ticker](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__hal__lp__ticker.html). This change is necessary to avoid drift connected with using two different timers to measure time. Users must not change the low power ticker interrupt handler when tickless mode is in use.
 
 #### Testing
 


### PR DESCRIPTION
This PR is for update the testing section in the contributing docs.
ref. `IOTHAL-56`

following updates included
* add testing section in the rtos page
* add testing section in the target page
* update the doxgen links in the tickless page