### PR TITLE
Remove outdated references to FEATURE_NANOSTACK, COMMON_PAL or others.

### DIFF
--- a/docs/reference/configuration/mesh.md
+++ b/docs/reference/configuration/mesh.md
@@ -23,7 +23,6 @@ An example of the configuration file:
 {
     "target_overrides": {
         "*": {
-            "target.features_add": ["NANOSTACK", "COMMON_PAL"],
             "nanostack.configuration": "lowpan_router",
             "mbed-mesh-api.6lowpan-nd-device-type": "NET_6LOWPAN_ROUTER",
             "mbed-mesh-api.6lowpan-nd-channel": 12,

--- a/docs/reference/contributing/connectivity/MeshInterface.md
+++ b/docs/reference/contributing/connectivity/MeshInterface.md
@@ -16,10 +16,10 @@ The Mbed OS port of Nanostack consists of a few helper modules that provide an e
     - Security settings.
     - Channel configuration.
     - Connection and reconnection logic.
-- [nanostack-hal-mbed-cmsis-rtos](https://github.com/ARMmbed/mbed-os/tree/master/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos) implements Platform API for Mbed OS.
+- [nanostack-hal-mbed-cmsis-rtos](https://github.com/ARMmbed/mbed-os/tree/master/features/nanostack/nanostack-hal-mbed-cmsis-rtos) implements Platform API for Mbed OS.
     - An internal event handler is initialized when the stack starts.
     - The event handler is running in its own thread. Not visible for users.
-- [NanostackInterface](https://github.com/ARMmbed/mbed-os/tree/master/features/nanostack/FEATURE_NANOSTACK/nanostack-interface) class implements the network stack abstraction for the socket layer.
+- [NanostackInterface](https://github.com/ARMmbed/mbed-os/tree/master/features/nanostack/nanostack-interface) class implements the network stack abstraction for the socket layer.
     - Initializes the RF driver. See [Providing RF driver](#providing-rf-driver-for-mbed-os-applications).
 
 In Mbed OS, Socket API hides the differences between the networking stacks. Users will only use one of its high level APIs:
@@ -42,7 +42,7 @@ For Mbed OS 5, the RF driver implements the `NanostackRfPhy` API. `MeshInterface
 
 Applications use only `LoWPANNDInterface` or `ThreadInterface` directly to set up the network and provide a driver. The rest of the classes provide an abstration between Nanostack and Socket layers of Mbed OS.
 
-See [NanostackRfPhy.h](https://github.com/ARMmbed/mbed-os/blob/master/features/nanostack/FEATURE_NANOSTACK/nanostack-interface/NanostackRfPhy.h) for an up-to-date header file and API.
+See [NanostackRfPhy](https://os.mbed.com/docs/latest/mbed-os-api-doxy/class_nanostack_rf_phy.html) for an up-to-date header file and API.
 
 ### Device Driver API
 

--- a/docs/tools/mbed_targets.md
+++ b/docs/tools/mbed_targets.md
@@ -130,22 +130,7 @@ When you use target inheritance, you may alter the values of `extra_labels` usin
 The list of _features_ enables software features on a platform. Like `extra_labels`, `features` makes the build system aware of additional directories it must scan for resources. Unlike `extra_labels`, the build system recognizes a fixed set of values in the `features` list. The build system recognizes the following features:
  - `UVISOR`.
  - `BLE`.
- - `CLIENT`.
- - `IPV4`.
- - `LWIP`.
- - `COMMON_PAL`.
  - `STORAGE`.
- - `NANOSTACK`.
-
-The following features, also recognized by the build system, are all Nanostack configurations:
- - `LOWPAN_BORDER_ROUTER`.
- - `LOWPAN_HOST`.
- - `LOWPAN_ROUTER`.
- - `NANOSTACK_FULL`.
- - `THREAD_BORDER_ROUTER`.
- - `THREAD_END_DEVICE`.
- - `THREAD_ROUTER`.
- - `ETHERNET_HOST`.
 
 The build system errors when you use features outside of this list.
 


### PR DESCRIPTION
In Mbed OS 5.10 all network related "features" have been removed.
This is transparent change to applications, as those code blocks are
now always enabled in the build.
Only visible change is that applications do not need to explicitly
request FEATURE_NANOSTACK or others, and targets do not need to enable
FEATURE_LWIP to provide ethernet driver.

@AnotherButler Please review.
@MarceloSalazar Please review from technical point of view.
