### PR TITLE
Removing mention of the export 'projectfiles' directory

### DIFF
--- a/docs/tools/offline/cli-collaborate.md
+++ b/docs/tools/offline/cli-collaborate.md
@@ -99,7 +99,7 @@ For example, to export to uVision, run:
 $ mbed export -i uvision -m K64F
 ```
 
-Mbed CLI creates a `.uvprojx` file in the projectfiles/uvision folder. You can open the project file with uVision.
+Mbed CLI creates a `.uvprojx` file in the root project directory. You can open the project file with uVision.
 
 ### Publishing changes
 

--- a/docs/tools/testing/testing.md
+++ b/docs/tools/testing/testing.md
@@ -140,7 +140,7 @@ Once you've copied all of the test's source files to your project root, export y
 mbed export -i <IDE name>
 ```
 
-You can find your exported project in `projectfiles/<IDE>_<target>`.
+You can find your exported project in the root project directory.
 
 #### Running a test while debugging
 


### PR DESCRIPTION
`mbed export` hasn't placed exported projects in the `projectfiles` directory for quite some time. They are now placed in the root directory.

FYI @theotherjimmy 