### PR TITLE
Create guidelines for the mbedtls_platform_context

### DIFF
--- a/docs/reference/api/security/TLS.md
+++ b/docs/reference/api/security/TLS.md
@@ -43,10 +43,11 @@ Then create a file named `mbed_app.json` at the root of your application with th
 
 ### Mbed TLS platform context
 
-Some hardware accelerators require initialization, regardless of specific cryptography engine. For this, `mbedtls_platform_setup()` and `mbedtls_platform_terminate()` was introduced.
+Some hardware accelerators require initialization, regardless of the specific cryptography engine. For this, we introduced `mbedtls_platform_setup()` and `mbedtls_platform_terminate()`.
 
-As shown in the [examples](#mbed-tls-examples), you *must* call the `mbedtls_platform_setup()` function before you call any Mbed TLS API. After using the Mbed TLS API, you *must* call `mbedtls_platform_teardown()`, to terminate the platform hardware driver. The platform context parameter for these function *should* be `NULL`.
+As the [examples](#mbed-tls-examples) show, you *must* call the `mbedtls_platform_setup()` function before you call any Mbed TLS API. After using the Mbed TLS API, you *must* call `mbedtls_platform_teardown()` to terminate the platform hardware driver. The platform context parameter for these function *should* be `NULL`.
 
+```
     int exit_code = MBEDTLS_EXIT_FAILURE;
 
     if((exit_code = mbedtls_platform_setup(NULL)) != 0) {
@@ -58,6 +59,7 @@ As shown in the [examples](#mbed-tls-examples), you *must* call the `mbedtls_pla
 
     mbedtls_platform_teardown(NULL);
     return exit_code;
+```
 
 ### Other resources
 

--- a/docs/reference/api/security/TLS.md
+++ b/docs/reference/api/security/TLS.md
@@ -45,7 +45,7 @@ Then create a file named `mbed_app.json` at the root of your application with th
 
 Some hardware accelerators require initialization, regardless of the specific cryptography engine. For this, we introduced `mbedtls_platform_setup()` and `mbedtls_platform_terminate()`.
 
-As the [examples](#mbed-tls-examples) show, you *must* call the `mbedtls_platform_setup()` function before you call any Mbed TLS API. After using the Mbed TLS API, you *must* call `mbedtls_platform_teardown()` to terminate the platform hardware driver. The platform context parameter for these function *should* be `NULL`.
+As the [examples](#mbed-tls-examples) show, you *must* call the `mbedtls_platform_setup()` function before you call any Mbed TLS API. After using the Mbed TLS API, you *must* call `mbedtls_platform_teardown()` to terminate the platform hardware driver. We suggest you set the platform context parameter for these functions as `NULL`.
 
 ```
     int exit_code = MBEDTLS_EXIT_FAILURE;

--- a/docs/reference/api/security/TLS.md
+++ b/docs/reference/api/security/TLS.md
@@ -41,6 +41,24 @@ Then create a file named `mbed_app.json` at the root of your application with th
 }
 ```
 
+### Mbed TLS platform context
+
+Some hardware accelerators require initialization, regardless of specific cryptography engine. For this, `mbedtls_platform_setup()` and `mbedtls_platform_terminate()` was introduced.
+
+As shown in the [examples](#mbed-tls-examples), you *must* call the `mbedtls_platform_setup()` function before you call any Mbed TLS API. After using the Mbed TLS API, you *must* call `mbedtls_platform_teardown()`, to terminate the platform hardware driver. The platform context parameter for these function *should* be `NULL`.
+
+    int exit_code = MBEDTLS_EXIT_FAILURE;
+
+    if((exit_code = mbedtls_platform_setup(NULL)) != 0) {
+        mbedtls_printf("Platform initialization failed with error %d\r\n", exit_code);
+        return MBEDTLS_EXIT_FAILURE;
+    }
+
+    /* call Mbed TLS code here */
+
+    mbedtls_platform_teardown(NULL);
+    return exit_code;
+
 ### Other resources
 
 The [Mbed TLS website](https://tls.mbed.org) contains many other useful resources for developers, such as [developer documentation](https://tls.mbed.org/dev-corner), [knowledge base articles](https://tls.mbed.org/kb) and a [support forum](https://tls.mbed.org/discussions).

--- a/docs/reference/api/security/TLS.md
+++ b/docs/reference/api/security/TLS.md
@@ -45,20 +45,20 @@ Then create a file named `mbed_app.json` at the root of your application with th
 
 Some hardware accelerators require initialization, regardless of the specific cryptography engine. For this, we introduced `mbedtls_platform_setup()` and `mbedtls_platform_terminate()`.
 
-As the [examples](#mbed-tls-examples) show, you *must* call the `mbedtls_platform_setup()` function before you call any Mbed TLS API. After using the Mbed TLS API, you *must* call `mbedtls_platform_teardown()` to terminate the platform hardware driver. We suggest you set the platform context parameter for these functions as `NULL`.
+As the [examples](#mbed-tls-examples) show, you *must* call the `mbedtls_platform_setup()` function before you call any Mbed TLS API. After using the Mbed TLS API, you *must* call `mbedtls_platform_teardown()` to terminate the platform hardware driver. For readability reasons, we suggest you set the platform context parameter for these functions as `NULL`, as it is not being used in Mbed OS.
 
 ```
-    int exit_code = MBEDTLS_EXIT_FAILURE;
+    int ret = 0;
 
-    if((exit_code = mbedtls_platform_setup(NULL)) != 0) {
-        mbedtls_printf("Platform initialization failed with error %d\r\n", exit_code);
-        return MBEDTLS_EXIT_FAILURE;
+    if((ret = mbedtls_platform_setup(NULL)) != 0) {
+        mbedtls_printf("Platform initialization failed with error %d\r\n", ret);
+        return ret;
     }
 
     /* call Mbed TLS code here */
 
     mbedtls_platform_teardown(NULL);
-    return exit_code;
+    return ret;
 ```
 
 ### Other resources

--- a/docs/reference/api/security/TLS.md
+++ b/docs/reference/api/security/TLS.md
@@ -52,13 +52,13 @@ As the [examples](#mbed-tls-examples) show, you *must* call the `mbedtls_platfor
 
     if((ret = mbedtls_platform_setup(NULL)) != 0) {
         mbedtls_printf("Platform initialization failed with error %d\r\n", ret);
-        return ret;
+        return 1;
     }
 
     /* call Mbed TLS code here */
 
     mbedtls_platform_teardown(NULL);
-    return ret;
+    return 0;
 ```
 
 ### Other resources

--- a/docs/reference/contributing/target/hw-accelerated-crypto.md
+++ b/docs/reference/contributing/target/hw-accelerated-crypto.md
@@ -133,6 +133,16 @@ To replace a module you have to:
 
 The default implementation of the modules are usually in the file `feature/mbedtls/src/<Module Name>.c`. The ECP module is split to two files: `ecp.c` and `ecp_curves.c`.
 
+### Mbed TLS platform context
+
+Some hardware accelerators require initialization, regardless of specific cryptography engine. For this, `mbedtls_platform_setup()` and `mbedtls_platform_terminate()` was introduced.
+
+When your hardware accelerator driver requires initialization, you should do the following operations:
+
+1. Define `MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT` in `mbedtls_device.h`
+1. Implement `crypto_platform_setup(crypto_platform_ctx *ctx)` and `crypto_platform_terminate(crypto_platform_ctx *ctx)` that will initialize and terminate your hardware accelerator driver.
+1. Define `crypto_platform_ctx` in `crypto_platform.h` in a way that suits your implementation.
+
 ### Considerations for alternative implementations
 
 #### Concurrency

--- a/docs/reference/contributing/target/hw-accelerated-crypto.md
+++ b/docs/reference/contributing/target/hw-accelerated-crypto.md
@@ -135,13 +135,7 @@ The default implementation of the modules are usually in the file `feature/mbedt
 
 ### Mbed TLS platform context
 
-Some hardware accelerators require initialization, regardless of specific cryptography engine. For this, `mbedtls_platform_setup()` and `mbedtls_platform_terminate()` was introduced.
-
-When your hardware accelerator driver requires initialization, you should do the following operations:
-
-1. Define `MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT` in `mbedtls_device.h`
-1. Implement `crypto_platform_setup(crypto_platform_ctx *ctx)` and `crypto_platform_terminate(crypto_platform_ctx *ctx)` that will initialize and terminate your hardware accelerator driver.
-1. Define `crypto_platform_ctx` in `crypto_platform.h` in a way that suits your implementation.
+Some hardware accelerators require initialization, regardless of specific cryptography engine. For instructions on how to do this, please see our [security page](/docs/development/apis/tls.html#mbed-tls-platform-context).
 
 ### Considerations for alternative implementations
 

--- a/docs/reference/contributing/target/hw-accelerated-crypto.md
+++ b/docs/reference/contributing/target/hw-accelerated-crypto.md
@@ -135,7 +135,13 @@ The default implementation of the modules are usually in the file `feature/mbedt
 
 ### Mbed TLS platform context
 
-Some hardware accelerators require initialization, regardless of specific cryptography engine. For instructions on how to do this, please see our [security page](/docs/development/apis/tls.html#mbed-tls-platform-context).
+Some hardware accelerators require initialization, regardless of the specific cryptography engine. For this, we introduced `mbedtls_platform_setup()` and `mbedtls_platform_terminate()`.
+
+When your hardware accelerator driver requires initialization, do the following operations:
+
+1. Define `MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT` in `mbedtls_device.h`
+1. Implement `crypto_platform_setup(crypto_platform_ctx *ctx)` and `crypto_platform_terminate(crypto_platform_ctx *ctx)`, which initializes and terminates your hardware accelerator driver.
+1. Define `crypto_platform_ctx` in `crypto_platform.h`.
 
 ### Considerations for alternative implementations
 


### PR DESCRIPTION
1. Add guidelines for Applications to call the platform API
2. Add guidelines on how to port an alternative platform context.