### PR TITLE
Close string quotes in docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -839,7 +839,7 @@
                     },
                     {
                         "type": "markdown",
-                        "url": "https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/tools/testing/testing_greentea.md
+                        "url": "https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/tools/testing/testing_greentea.md"
                     },
                     {
                         "type": "markdown",


### PR DESCRIPTION
JSON format was invalid due to missing string termination.

@AnotherButler 