### PR TITLE
Note about permissions

### DIFF
--- a/docs/tools/offline/cli-device-management.md
+++ b/docs/tools/offline/cli-device-management.md
@@ -11,7 +11,7 @@ $ mbed config -G CLOUD_SDK_API_KEY <API_KEY>
 $ mbed target K64F
 $ mbed toolchain GCC_ARM
 ```
-<span class="notes">**Note:** The API key must have Administrator priveledges to use this feature.</span>
+<span class="notes">**Note:** The API key must have Administrator privileges to use this feature.</span>
 
 Initialize the device management feature of Mbed CLI with the following command:
 

--- a/docs/tools/offline/cli-device-management.md
+++ b/docs/tools/offline/cli-device-management.md
@@ -11,6 +11,7 @@ $ mbed config -G CLOUD_SDK_API_KEY <API_KEY>
 $ mbed target K64F
 $ mbed toolchain GCC_ARM
 ```
+<span class="notes">**Note:** The API key must have Administrator priveledges to use this feature.</span>
 
 Initialize the device management feature of Mbed CLI with the following command:
 


### PR DESCRIPTION
Related to https://github.com/ARMmbed/mbed-cli/issues/746  (INTERNAL MBOTRIAGE-1595) 

In order to temporarily enable OOB and users of the `mbed dm` feature, we should add in this Note. 

This does not solve the overarching issue about a Developer vs Administrator API key allowing to generate a developer credentials file.