### PR TITLE
Add labels to PR stages

### DIFF
--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -165,18 +165,21 @@ All pull requests must be reviewed. The Arm Mbed CI bot determines the most suit
 
 Github dismisses a reviewer's status after any change to the pull request commit history (such as adding a new commit or rebasing). Smaller changes, such as documentation edits or rebases on top of latest master, only require additional review by maintainers. Their approval is sufficient because a team assigned as a reviewer already approved the pull request.
 
+Label: `needs: CI`
 Time: 3 days for reviewers to leave feedback after the maintainers add the "needs: review" label.
 
 #### The CI (Continuous Integration) testing
 
 There are many CI systems available. Which CI tests we run against a particular pull request depends on the effect that pull request has on the code base. Irrespective of which CI tests run, Mbed OS has an all green policy, meaning that all the CI jobs that are triggered must pass before we merge the pull request.
 
+Label: `needs: review`
 Time: 1 day for CI to complete and report back results.
 
 #### Work needed
 
 A pull request in the work needed state requires additional work due to failed tests, or rework as a result of the review. If a pull request is in this state, then our maintainers request changes from the pull request author.
 
+Label: `needs: work`
 Time: 3 days for the pull request author to action the review comments.
 
 #### Releases

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -182,6 +182,13 @@ A pull request in the work needed state requires additional work due to failed t
 Label: `needs: work`
 Time: 3 days for the pull request author to action the review comments.
 
+#### Ready for integration
+
+Pull requests are merged by maintainers during the internal gatekeeping meetings. They take place 3 times a week. Straightforward pull requests can be merged immediately.
+
+Label: `Ready for merge`
+Time: 2 days
+
 #### Releases
 
 When we merge a pull request that we will publish in a patch release, we tag the pull request with the specific patch release version. This is the release in which we first publish this pull request. For patch releases, we allow only bug fixes, new targets and enhancements to existing functionality. New features only go in feature releases.

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -204,7 +204,7 @@ We use many other labels to summarize the scope and effect of the changes.
 - *needs: preceding PR* - This pull request cannot yet be merged because it has a dependency on another pull request that needs to merge first.
 - *DO NOT MERGE* - This pull request contains changes that may be in a draft state and submitted purely for review, or may contain breaking changes that have not been considered.
 - *devices: 'name'* - The pull request specifically affects the named device(s).
-- *component: 'name'* - The pull request specifically affects the named component.
+- *component: 'name'* - The pull request specifically affects the named component. Component names follow the structure of Mbed OS (ble, storage, tls, ... etc)
 
 The following labels summarize the scope of the pull request.
 

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -184,7 +184,7 @@ Time: 3 days for the pull request author to action the review comments.
 
 #### Ready for integration
 
-Pull requests are merged by maintainers during the internal gatekeeping meetings. They take place 3 times a week. Straightforward pull requests can be merged immediately.
+Maintainers merge pull requests during the internal gatekeeping meetings that occur three times a week. They can merge straightforward pull requests immediately.
 
 Label: `Ready for merge`
 Time: 2 days
@@ -204,7 +204,7 @@ We use many other labels to summarize the scope and effect of the changes.
 - *needs: preceding PR* - This pull request cannot yet be merged because it has a dependency on another pull request that needs to merge first.
 - *DO NOT MERGE* - This pull request contains changes that may be in a draft state and submitted purely for review, or may contain breaking changes that have not been considered.
 - *devices: 'name'* - The pull request specifically affects the named device(s).
-- *component: 'name'* - The pull request specifically affects the named component. Component names follow the structure of Mbed OS (ble, storage, tls, ... etc)
+- *component: 'name'* - The pull request specifically affects the named component. Component names follow the structure of Mbed OS (`ble`, `storage`, `tls` and so on).
 
 The following labels summarize the scope of the pull request.
 


### PR DESCRIPTION
+ define what is a component

Questions:

- regarding components: we might want to list all of available or would it be clear from Mbed OS structure?
- I defined "ready for merge" as: does not mean it will be instantly merged, expecting to be checked during gatekeeping but most cases (simple PR) can be merged immediately - how it is
- we are still missing here  the information about our CI @OPpuolitaival I would like your help here to add a section here to add `CI` and provide info about public information that we have on each pull request (separate PR that would address this)

cc @SeppoTakalo @AnttiKauppila @ARMmbed/mbed-os-maintainers 