### PR TITLE
Clarify usage of custom bootloader

### DIFF
--- a/docs/tutorials/bootloader.md
+++ b/docs/tutorials/bootloader.md
@@ -61,6 +61,7 @@ To create an application using a bootloader, you must first have created the boo
 "target_overrides": {
     ...
     "<TARGET_NAME>": {
+        "target.features_add": ["BOOTLOADER"],
         "target.bootloader_img": "bootloader/my_bootloader.bin"
     },
     ...
@@ -165,6 +166,7 @@ You can place the prebuilt binary bootloader in `mbed-os/feature/FEATURE_BOOTLOA
    ```
    "target_overrides": {
            "YOUR_TARGET": {
+               "target.features_add": ["BOOTLOADER"],
                "target.app_offset": "0x10400",
                "target.header_offset": "0x10000",
                "target.header_format": [
@@ -184,6 +186,7 @@ Alternatively, you can edit `mbed_app.json`, and override the target bootloader 
    ```
        "target_overrides": {
            "YOUR_TARGET": {
+               "target.features_add": ["BOOTLOADER"],
                "target.bootloader_img": "PATH_TO_BOOTLOADER/your_bootloader.bin"
                "target.app_offset": "0x10400",
                "target.header_offset": "0x10000",


### PR DESCRIPTION
During development of applications and usage of the custom bootloader feature, I've noticed the header of the bootloader was not being been included at compile time.

```
  Region bootloader: size 0x8000, offset 0x8000000
  Region header: size 0x70, offset 0x8010000   <------- was missing
  Region application: size 0x1efc00, offset 0x8010400
```

And the bootloader was not working ok.

Adding `"target.features_add": ["BOOTLOADER"]` seems to solve the problem.

cc @bogdanm @theotherjimmy @AnotherButler 