### PR TITLE
Fix flow-control tutorial link

### DIFF
--- a/docs/api/rtos/Thread.md
+++ b/docs/api/rtos/Thread.md
@@ -83,4 +83,5 @@ The Callback API provides a convenient way to pass arguments to spawned threads.
 
 ### Related content
 
-- [Application flow control tutorial](docs/development/tutorials/application-flow-control.html).
+- [Application flow control tutorial](docs/development/tutorials/using_apis/flow-control.html).
+


### PR DESCRIPTION
@AnotherButler Can you confirm the new link is correct? Should point here:
https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/tutorials/using_apis/flow_control.md 