### PR TITLE
Move bootloader configuration from tools to reference

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -693,6 +693,10 @@
                     {
                         "type": "markdown",
                         "url": "https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/reference/configuration/Storage.md"
+                    },
+                    {
+                        "type": "markdown",
+                        "url": "https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/tools/bootloader.md"
                     }
                 ]
             },
@@ -935,11 +939,8 @@
                 ]
             },
             {
-                "title": "Configuring Tools",
-                "sources": [{
-                        "type": "markdown",
-                        "url": "https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/tools/bootloader.md"
-                    },
+                "title": "Configuring Targets",
+                "sources": [
                     {
                         "type": "markdown",
                         "url": "https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/tools/mbed_targets.md"


### PR DESCRIPTION
### Description

As we have had several people stumble over finding this document, I'm
moving it to where they expected to find it. Personally, I also found
it odd that the landing page for configuring tools was some bootloader
configuration refenece.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change