### PR TITLE
Add GitHub profile requirement and update issue tracking

### DIFF
--- a/docs/reference/contributing/guidelines/guidelines.md
+++ b/docs/reference/contributing/guidelines/guidelines.md
@@ -12,4 +12,24 @@ The process how and how we review contributions is described in the [workflow](w
 
 #### Licenses
 
-License should comply with allowed [licenses described](license.html).
+License should comply with allowed [licenses described](license.html). 
+
+#### Access to the ARMmbed organisation
+
+If you require direct access to the ARMmbed organisation for one of the following reasons:
+
+* You need access to private repositories
+* You need push access to a repository
+* You are colloborating with Arm staff
+
+then you can request to become an organisation member. Prior to this you must ensure your GitHub profile
+meets the following requirements:
+
+* All users must have 2 Factor Authentication enabled
+
+* Arm staff must have their Name, Company (Arm), Location and Arm email address publicly visible
+
+* All others should have their Name and Company visible. Location would be beneficial as it enables 
+  us to know your region and thus interpret response times accordingly.
+
+

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -38,11 +38,11 @@ Please create separate pull requests for each concern; each pull request needs a
 
 #### Reporting bugs
 
-Please submit all Mbed OS bugs [on the forums](https://os.mbed.com/forum/bugs-suggestions/).
+Mbed OS bugs may be submitted [on the forums](https://os.mbed.com/forum/bugs-suggestions/) or directly [on GitHub](https://github.com/ARMmbed/mbed-os)
 
 The bug report should be reproducible (fails for others) and specific (where and how it fails). We will close insufficient bug reports.
 
-We copy issues reported on GitHub to our internal tracker (`ARM Internal Ref: MBOTRIAGE-XXX` comment in the issues and label mirrored set once copied) and regularly triage them.
+We copy issues reported on GitHub to our internal tracker (`Internal Jira reference: https://jira.arm.com/browse/MBOCUSTRIA-xxx` comment in the issues and label mirrored set once copied) and regularly triage them.
 
 ### Guidelines for GitHub pull requests
 


### PR DESCRIPTION
The new requirements for all GitHub profiles has been added to the
Contributing document.

Workflow has been updated to add a comment about also submitting
issues directly on GitHub and correcting the comment that is added
when the issue is mirrored.