### PR TITLE
Add validation for code snippets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,106 @@
+# Language and cache settings
+language: python
+python: 2.7
+cache:
+  pip: true
+  directories:
+    - $HOME/.cache/apt
+
+# Common install step
+install:
+  # Make sure pipefail
+  - set -o pipefail
+  # Set up apt to cache
+  - mkdir -p $HOME/.cache/apt/partial
+  - sudo rm -rf /var/cache/apt/archives
+  - sudo ln -s $HOME/.cache/apt /var/cache/apt/archives
+  # Set up ppa to make sure arm-none-eabi-gcc is the correct version
+  - sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
+  # Fix for "The following signatures were invalid: KEYEXPIRED 1515625755" failed". See https://github.com/travis-ci/travis-ci/issues/9037
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6
+  # Loop until update succeeds (timeouts can occur)
+  - travis_retry $(! sudo apt-get update 2>&1 | grep Failed)
+  # Finally install gcc-arm-embedded
+  - sudo apt-get install gcc-arm-embedded
+  # Get mbed-os
+  - git clone https://github.com/armmbed/mbed-os.git
+  # Install python dependencies
+  - pip install -r mbed-os/requirements.txt
+
+# CI matrix
+jobs:
+  include:
+    # native testing
+    - stage: test
+      env:
+        - NAME=code-snippets
+      script:
+        # Run script to validate code snippets
+        - ./check_tools/find_bad_code_snippets.sh
+        # Grep to find remaining TODOs
+        - |
+            TODO_COUNT=0
+            for f in $(find -name mbed-os -prune -o -name '*.md' -print)
+            do
+                for l in $(sed -n '/```.*TODO/I=' $f)
+                do
+                    echo "TODO in $f line $l"
+                    TODO_COUNT=$(expr $TODO_COUNT + 1)
+                done
+            done
+            echo "Total number of TODOs: $TODO_COUNT"
+        # Update status with number of found TODOs if we passed testing
+        - |
+            if [ "$TRAVIS_TEST_RESULT" -eq 0 ]
+            then
+                CURR=$TODO_COUNT
+                PREV=$(curl -u "$MBED_BOT" https://api.github.com/repos/$TRAVIS_REPO_SLUG/status/master \
+                    | jq -re "select(.sha != \"$TRAVIS_COMMIT\")
+                        | .statuses[] | select(.context == \"$STAGE/$NAME\").description
+                        | capture(\"(?<count>[0-9]+) TODOs\").count" \
+                    || echo 0)
+                STATUS="Passed, ${CURR} TODOs"
+                if [ "$PREV" -ne 0 ]
+                then
+                    STATUS="$STATUS ($(python -c "print '%+d' % ($CURR-$PREV)") TODOs)"
+                fi
+            fi
+
+# Manage statuses
+before_install:
+  - |
+    curl -u "$MBED_BOT" -X POST \
+        https://api.github.com/repos/$TRAVIS_REPO_SLUG/statuses/${TRAVIS_PULL_REQUEST_SHA:-$TRAVIS_COMMIT} \
+        -d "{
+            \"context\": \"travis-ci/$NAME\",
+            \"state\": \"pending\",
+            \"description\": \"${STATUS:-In progress}\",
+            \"target_url\": \"https://travis-ci.org/$TRAVIS_REPO_SLUG/jobs/$TRAVIS_JOB_ID\"
+        }"
+
+after_failure:
+  - |
+    curl -u "$MBED_BOT" -X POST \
+        https://api.github.com/repos/$TRAVIS_REPO_SLUG/statuses/${TRAVIS_PULL_REQUEST_SHA:-$TRAVIS_COMMIT} \
+        -d "{
+            \"context\": \"travis-ci/$NAME\",
+            \"state\": \"failure\",
+            \"description\": \"${STATUS:-Failed}\",
+            \"target_url\": \"https://travis-ci.org/$TRAVIS_REPO_SLUG/jobs/$TRAVIS_JOB_ID\"
+        }"
+
+after_success:
+  - |
+    curl -u "$MBED_BOT" -X POST \
+        https://api.github.com/repos/$TRAVIS_REPO_SLUG/statuses/${TRAVIS_PULL_REQUEST_SHA:-$TRAVIS_COMMIT} \
+        -d "{
+            \"context\": \"travis-ci/$NAME\",
+            \"state\": \"success\",
+            \"description\": \"${STATUS:-Passed}\",
+            \"target_url\": \"https://travis-ci.org/$TRAVIS_REPO_SLUG/jobs/$TRAVIS_JOB_ID\"
+        }"
+
+# Job control
+stages:
+    - name: test
+

--- a/check_tools/find_bad_code_snippets.sh
+++ b/check_tools/find_bad_code_snippets.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -eo pipefail
+
+mkdir -p BUILD
+echo '*' > BUILD/.mbedignore
+
+# simple fake main for snippets without a main function
+cat > fake_main.c <<MAIN
+#include "mbed_toolchain.h"
+MBED_WEAK int main(void) { return 0; }
+MAIN
+
+function compile {
+    if [ "$1" != "NOCI" -a "$1" != "TODO" ]
+    then
+        PYTHONPATH=mbed-os python mbed-os/tools/make.py -t GCC_ARM -m ${1:-K64F} --source=. --build=BUILD/${1:-K64F}/GCC_ARM | sed '/\(error\|warning\)/I!d'
+    fi
+}
+     
+for f in $(find -name mbed-os -prune -o -name '*.md' -print)
+do
+    # compile c++ snippets
+    for l in $(sed -n '/``` *\(cpp\|c++\)\($\| \+\)/I=' $f)
+    do
+        echo "Validating cpp $f:$l ..."
+        echo "#include \"mbed.h\"" > main.cpp
+        sed -n $l',/```/{/```/d;p}' $f >> main.cpp
+        compile "$(sed -n $l's/ *``` *\(cpp\|c++\)\($\| \+\)//Ip' $f)"
+        rm main.cpp
+    done
+    
+    # compile c snippets
+    for l in $(sed -n '/``` *c\($\| \+\)/I=' $f)
+    do
+        echo "Validating c $f:$l ..."
+        sed -n $l',/```/{/```/d;p}' $f > main.c
+        compile "$(sed -n $l's/ *``` *c\($\| \+\)//Ip' $f)"
+        rm main.c
+    done
+
+    # validate json snippets
+    for l in $(sed -n '/``` *json\($\| \+\)/I=' $f)
+    do
+        echo "Validating json $f:$l ..."
+        sed -n $l',/```/{/```/d;p}' $f > main.json
+        if [ "$(sed -n $l's/ *``` *json\($\| \+\)//Ip' $f)" != "NO" ]
+        then
+            if sed -n '/ *"/q0;/ *[^ ]/q1' main.json
+            then
+                (echo "{" ; cat main.json ; echo "}") | python -m json.tool > /dev/null
+            else
+                cat main.json | python -m json.tool > /dev/null
+            fi
+        fi
+        rm main.json
+    done
+done

--- a/docs/api/bluetooth/BLE.md
+++ b/docs/api/bluetooth/BLE.md
@@ -30,7 +30,7 @@ You can build a BLE application using Mbed OS, `BLE_API` and a controller-specif
 
 The entry point of Mbed's `BLE_API` is the BLE class accessible using the header `ble/BLE.h`. This class allows you to obtain a BLE object that includes the basic attributes of a spec-compatible BLE device and can work with any BLE radio:
 
-```c
+```c TODO
 #include "ble/BLE.h"
 
 BLE& mydevicename = BLE::Instance();

--- a/docs/api/drivers/Devicekey.md
+++ b/docs/api/drivers/Devicekey.md
@@ -37,7 +37,7 @@ DeviceKey is a singleton class, meaning that the system can have only a single i
 
 To instantiate DeviceKey, you need to call its `get_instance` member function as following:
 
-```c++
+```c++ TODO
     DeviceKey &deviceKey = DeviceKey::get_instance();
 ```
 

--- a/docs/api/drivers/I2CSlave.md
+++ b/docs/api/drivers/I2CSlave.md
@@ -12,7 +12,7 @@ Synchronization level: not protected.
 
 Try this example to see how an I2C responder works.
 
-```c++
+```c++ TODO
 #include <mbed.h>
 
 I2CSlave slave(p9, p10);

--- a/docs/api/drivers/SPISlave.md
+++ b/docs/api/drivers/SPISlave.md
@@ -17,7 +17,7 @@ Reply to a SPI master as slave:
 ```c++
 #include "mbed.h"
 
-SPISlave device(p5, p6, p7, p8); // mosi, miso, sclk, ssel
+SPISlave device(D9, D11, D12, D13); // mosi, miso, sclk, ssel
 
 int main() {
    device.reply(0x00);              // Prime SPI with first reply

--- a/docs/api/lorawan/lorawanintro.md
+++ b/docs/api/lorawan/lorawanintro.md
@@ -12,33 +12,33 @@ To bring up the Mbed LoRaWAN stack, consider the following progression:
 
 1) An [EventQueue](eventqueue.html) object:
 
-```cpp
+```cpp TODO
 // construct an event queue
 EventQueue ev_queue(NUM_EVENTS * EVENTS_EVENT_SIZE);
 ```
 
 2) A [LoRaRadio](lorawan-api.html) object:
 
-```CPP
+```CPP TODO
 // construct a LoRadio object
 SX1272_LoRaRadio radio(PIN_NAMES ... );
 ```
 
 3) Instantiate `LoRaWANInterface`, and pass `LoRaRadio` object:
 
-```CPP
+```CPP TODO
 LoRaWANInterface lorawan(radio) ;
 ```
 
 4) Initialize mac layer and pass `EventQueue` object:
 
-```CPP
+```CPP TODO
 lorawan.initialize(&ev_queue);
 ```
 
 5) Set up the event callback:
 
-```cpp
+```cpp TODO
 lorawan_app_callbacks_t callbacks
 callbacks.events = mbed::callback(YOUR_EVENT_HANDLER);
 lorawan.add_app_callbacks(&callbacks);
@@ -46,7 +46,7 @@ lorawan.add_app_callbacks(&callbacks);
 
 6) Add network credentials (security keys) and any configurations:
 
-```CPP
+```CPP TODO
 lorawan_connect_t connection;
 
 connection.connect_type = LORAWAN_CONNECTION_OTAA;
@@ -93,7 +93,7 @@ The Mbed LoRaWAN stack currently maps 3 different callbacks:
 
 An example of attaching your event handler to the stack:
 
-```CPP
+```CPP TODO
 
 void your_event_handler(lorawan_event_t event)
 {
@@ -118,7 +118,7 @@ lorawan.add_app_callbacks(&callbacks);
 
 Link check request is a MAC command defined by the LoRaWAN specification. To receive the response of this MAC command, set the `link_check_resp` callback.
 
-```CPP
+```CPP TODO
 void your_link_check_response(uint8_t demod_margin, uint8_t num_gw)
 {
 	//demod_margin is the demodulation margin
@@ -134,7 +134,7 @@ lorawan.add_app_callbacks(&callbacks);
 
 The battery level callback is different from others. The direction of this callback is from the application to the stack. In other words, it provides information to the stack. The application is reponsible for letting the stack know about the current battery level.
 
-```CPP
+```CPP TODO
 uint8_t your_battery_level()
 {
 	return battery_level;

--- a/docs/api/networkinterfaces/EthInterface.md
+++ b/docs/api/networkinterfaces/EthInterface.md
@@ -11,19 +11,19 @@ Ethernet driver for the target and select correct network stack.
 
 To statically initialize the driver, create an object without passing any parameters:
 
-```cpp
+```cpp TODO
 EthernetInterface eth;
 ```
 
 Then, if the default configuration is enough, bring up the interface:
 
-```cpp
+```cpp TODO
 nsapi_error_t status = eth.connect();
 ```
 
 Now, the interface is ready to be used for [network sockets](network-socket.html).
 
-```cpp
+```cpp TODO
 // Open a TCP socket
 TCPSocket socket;
 socket.open(&eth);

--- a/docs/api/networkinterfaces/NetworkStatus.md
+++ b/docs/api/networkinterfaces/NetworkStatus.md
@@ -24,7 +24,7 @@ The callback needs to handle these possible network states:
 
 This API requires an interface to be monitored. For example, Ethernet:
 
-```cpp
+```cpp TODO
 EthernetInterface eth;
 ```
 
@@ -56,7 +56,7 @@ void status_callback(nsapi_event_t status, intptr_t param)
 
 Now, the callback function is registered to the interface.
 
-```cpp
+```cpp TODO
     eth.attach(&status_callback);
 ```
 
@@ -64,7 +64,7 @@ This allows the application to monitor if network interface gets disconnected.
 
 Optionally, the application might want to set the `connect()` method to nonblocking mode and wait until connectivity is fully established.
 
-```cpp
+```cpp TODO
     eth.set_blocking(false);
     eth.connect();              // Return immediately
 ```

--- a/docs/api/networksocket/networksocket.md
+++ b/docs/api/networksocket/networksocket.md
@@ -104,7 +104,7 @@ The network socket API provides a common interface for using sockets on network 
 
 The convention of the network socket API is for functions to return negative error codes to indicate failure. On success, a function may return zero or a non-negative integer to indicate the size of a transaction. On failure, a function must return a negative integer, which is one of the error codes in the `nsapi_error_t` [enum](/docs/development/mbed-os-api-doxy/group__netsocket.html#gac21eb8156cf9af198349069cdc7afeba):
 
-``` cpp
+``` cpp NOCI
 /** Enum of standardized error codes
  *
  *  Valid error codes have negative values and may

--- a/docs/api/nfc/NFCController.md
+++ b/docs/api/nfc/NFCController.md
@@ -12,7 +12,7 @@ To use an NFC controller, you must initiate the instance with a driver instance,
 
 ### NFCController example
 
-```cpp
+```cpp TODO
 #include "stdint.h"
 
 #include "NFC.h"
@@ -36,7 +36,7 @@ A delegate mechanism handles events throughout the API.
 
 For instance, a delegate for a NFC controller can look similar to this:
 
-```cpp
+```cpp TODO
 struct NFCDelegate : mbed::nfc::NFCController::Delegate {
     virtual void on_discovery_terminated(nfc_discovery_terminated_reason_t reason) {
         printf("Discovery terminated:\r\n");

--- a/docs/api/nfc/NFCEEPROM.md
+++ b/docs/api/nfc/NFCEEPROM.md
@@ -12,7 +12,7 @@ To use an NFC EEPROM, you must initiate the instance with a driver instance, an 
 
 ### NFCEEPROM example
 
-```cpp
+```cpp TODO
 #include "stdint.h"
 
 #include "NFC.h"

--- a/docs/api/platform/Assert.md
+++ b/docs/api/platform/Assert.md
@@ -18,7 +18,7 @@ Note that the `MBED_ASSERT` macro is available in the debug and develop [build p
 
 The below function uses `MBED_ASSERT` to validate a pointer to `serial_t` object.
 
-```C
+```C TODO
 uint8_t serial_tx_active(serial_t *obj) {
     MBED_ASSERT(obj);
     ...
@@ -29,7 +29,7 @@ You can use the `MBED_STATIC_ASSERT` macro for compile-time evaluation of expres
 
 The below function uses `MBED_STATIC_ASSERT` to validate the size of the `equeue_timer` structure.
 
-```C
+```C TODO
 void equeue_tick_init() {
     MBED_STATIC_ASSERT(sizeof(equeue_timer) >= sizeof(Timer),"The equeue_timer buffer must fit the class Timer");
     ...

--- a/docs/api/platform/Debug.md
+++ b/docs/api/platform/Debug.md
@@ -4,7 +4,7 @@ Mbed OS provides a set of debug functions that you can use to output debug messa
 
 The `debug` function is a printf-style function that takes a format string followed by arguments. Below are some sample usages.
 
-```C
+```CPP TODO
 void *operator new(std::size_t count) {
     void *buffer = malloc(count);
     if (NULL == buffer) {
@@ -18,7 +18,7 @@ void *operator new(std::size_t count) {
 
 The `debug_if` function is similar to the `debug` function except that it takes an additional argument as its first parameter. The message prints to `STDIO` only if the first paramater evaluates to `true`.
 
-```C
+```C TODO
 void *operator new(std::size_t count) {
     debug_if( count == 0, "\nnew called with 0 size");
     ...

--- a/docs/api/platform/Error.md
+++ b/docs/api/platform/Error.md
@@ -142,7 +142,7 @@ The below link provides the documentation for all the APIs that Mbed OS provides
 
 The code below uses error function to print a fatal error indicating an out-of-memory condition.
 
-```C
+```CPP TODO
 void *operator new(std::size_t count) {
     void *buffer = malloc(count);
     if (NULL == buffer) {
@@ -156,7 +156,7 @@ void *operator new(std::size_t count) {
 
 The code below uses an `MBED_ERROR` macro to print a fatal error indicating an invalid argument with the module name specified as `MODULE_APPLICATION`:
 
-```C
+```CPP
 void receive_data(unsigned char *buffer) {
     if (NULL == buffer) {
         MBED_ERROR( MBED_MAKE_ERROR(MBED_MODULE_APPLICATION, MBED_ERROR_CODE_INVALID_ARGUMENT), "Buffer pointer is Null" );
@@ -170,7 +170,7 @@ void receive_data(unsigned char *buffer) {
 
 The code below uses an `MBED_WARNING` macro to report a invalid configuration attempt with the module name specified as `MBED_MODULE_PLATFORM`:
 
-```C
+```CPP
 mbed_error_status_t configure(int config_value) {
     if (config_value > 10) {
         //Log the fact that a invalid configuration attempt was made and return with error code
@@ -188,7 +188,7 @@ mbed_error_status_t configure(int config_value) {
 
 The `MBED_ERROR1` macro is similar to `MBED_ERROR` macro, but it can take an additional context-specific argument. The error handling system also records this value as part of the context capture. The code below uses the `MBED_ERROR1` macro to print a fatal error indicating an out-of-memory condition with a context specific value as the last argument to `MBED_ERROR1` macro:
 
-```C
+```CPP
 void receive_data(unsigned char *buffer) {
     if (NULL == buffer) {
         MBED_ERROR1(MBED_MAKE_ERROR(MBED_MODULE_APPLICATION, MBED_ERROR_CODE_INVALID_ARGUMENT), "Buffer pointer is Null", 1024/* Size of allocation which failed */ );
@@ -202,7 +202,7 @@ void receive_data(unsigned char *buffer) {
 
 The `MBED_WARNING1` macro is similar to the `MBED_WARNING` macro, but it can take an additional context-specific argument. The error handling system also records this value as part of the context capture. The code below uses the `MBED_WARNING1` macro to report a warning with a context specific value as the last argument to `MBED_WARNING1` macro:
 
-```C
+```CPP
 mbed_error_status_t configure(int config_value) {
     if (config_value > 10) {
         //Log the fact that a invalid configuration attempt was made and return with error code
@@ -220,7 +220,7 @@ mbed_error_status_t configure(int config_value) {
 
 The code below uses an `MBED_WARNING` macro to report a invalid configuration attempt without module name:
 
-```C
+```CPP
 mbed_error_status_t configure(int config_value) {
     if (config_value > 10) {
         //Log the fact that a invalid configuration attempt was made and return with error code
@@ -238,10 +238,10 @@ mbed_error_status_t configure(int config_value) {
 
 The code below uses the `mbed_get_first_error()` and `mbed_get_first_error_info()` functions to retrieve the first error or first warning logged in the system using `MBED_WARNING()/MBED_ERROR()` calls:
 
-```C
+```CPP
 void get_first_error_info() {
     mbed_error_status_t first_error_status = mbed_get_first_error();
-    printf("\nFirst error code = %d", MBED_GET_ERROR_CODE(first_error_status))
+    printf("\nFirst error code = %d", MBED_GET_ERROR_CODE(first_error_status));
 
     //Now retrieve more information associated with this error
     mbed_error_ctx first_error_ctx;
@@ -253,10 +253,10 @@ void get_first_error_info() {
 
 Use the functions `mbed_get_last_error()` and `mbed_get_last_error_info()` to retrieve the last error or last warning logged in the system using `MBED_WARNING()/MBED_ERROR()` calls. Note that these are similar to `mbed_get_first_error()` and `mbed_get_first_error_info()` calls, except that they retrieve the last error or last warning in this case:
 
-```C
+```CPP
 void get_last_error_info() {
     mbed_error_status_t last_error_status = mbed_get_last_error();
-    printf("\nLast error code = %d", MBED_GET_ERROR_CODE(last_error_status))
+    printf("\nLast error code = %d", MBED_GET_ERROR_CODE(last_error_status));
 
     //Now retrieve more information associated with this error
     mbed_error_ctx last_error_ctx;
@@ -268,7 +268,7 @@ void get_last_error_info() {
 
 You can use the function `mbed_get_error_hist_info()` to retrieve the error or warning information from the [error history](#error-history):
 
-```C
+```CPP TODO
 void get_error_info_from_hist() {
     //Retrieve error information from error history
     mbed_error_ctx hist_error_ctx;
@@ -289,7 +289,7 @@ void get_error_info_from_hist() {
 
 You can use the function `mbed_clear_all_errors()` to clear all currently logged errors from the [error history](#error-history). You can use this if you have already backed up all the currently logged errors (for example, to a file system or cloud) and want to capture new errors:
 
-```C
+```CPP
 void save_all_errors() {
     //Save the errors first
     save_all_errors();

--- a/docs/api/platform/IdleLoop.md
+++ b/docs/api/platform/IdleLoop.md
@@ -2,7 +2,7 @@
 
 Idle loop is a background system thread, which scheduler executes when no other threads are ready to run. That may happen when your application is waiting for an event to happen. By default, the idle loop invokes sleep manager to enter a sleep mode. You can overwrite this behavior by providing a different handler:
 
-```c++
+```c++ TODO
 void new_idle_loop()
 {
     // do nothing

--- a/docs/api/platform/platform.md
+++ b/docs/api/platform/platform.md
@@ -93,7 +93,7 @@ This API is sufficient for simple applications, but falls apart when there are m
 
 For example, consider applying a low-pass filter to two different ADC modules:
 
-``` c++
+``` c++ TODO
 // Here is a small running-average low-pass filter.
 float low_pass_result;
 void low_pass_step(float data) {
@@ -116,7 +116,7 @@ Without state, callbacks compose poorly. In C, you fix this by adding a "state" 
 
 Here’s the low-pass example using an additional argument for state.
 
-```c++
+```c++ TODO
 class ADC {
    public:
    // Here, the adc_callback_t type is a function that takes in data, as well as a pointer for state
@@ -155,7 +155,7 @@ One of the core features of C++ is the encapsulation of this "state" in classes,
 
 Here’s the low-pass filter example rewritten to use the callback class:
 
-``` c++
+``` c++ TODO
 class ADC {
 public:
     // In this example, the ADC read function calls the user-provided callback

--- a/docs/api/rtos/Mutex.md
+++ b/docs/api/rtos/Mutex.md
@@ -6,7 +6,7 @@ A Mutex is used to synchronize the execution of threads, for example to protect 
 
 The `Mutex` methods cannot be called from interrupt service routines (ISR). In the current version of Mbed OS, if you attempt to use a mutex from within an ISR, it will treat that as a fatal system error, and you will see an error like this:
 
-```C
+```
 ++ MbedOS Error Info ++
 Error Status: 0x80020115 Code: 277 Module: 2
 Error Message: Mutex lock failed

--- a/docs/api/storage/BufferedBlockDevice.md
+++ b/docs/api/storage/BufferedBlockDevice.md
@@ -18,7 +18,7 @@ To configure this class, please see our [BlockDevice configuration documentation
 
 This BufferedBlockDevice example takes a [HeapBlockDevice](heapblockdevice.html), whose read size is 256 bytes and program size is 512 bytes, and shows how one can read or program this block device with much smaller read/program sizes, using BufferedBlockDevice.
 
-```C++
+```C++ TODO
 
     HeapBlockDevice heap_bd(1024, 256, 512, 512);
     BufferedBlockDevice buf_bd(&heap_bd);

--- a/docs/api/storage/DataFlashBlockDevice.md
+++ b/docs/api/storage/DataFlashBlockDevice.md
@@ -14,7 +14,7 @@ To configure this class, please see our [BlockDevice configuration documentation
 
 ### DataFlashBlockDevice example:
 
-``` cpp
+``` cpp TODO
 // Here's an example using the AT45DB on the K64F
 #include "mbed.h"
 #include "DataFlashBlockDevice.h"

--- a/docs/api/storage/FlashIAPBlockDevice.md
+++ b/docs/api/storage/FlashIAPBlockDevice.md
@@ -17,7 +17,7 @@ To configure this class, please see our [BlockDevice configuration documentation
 
 ### FlashIAPBlockDevicesBlockDevice example:
 
-``` cpp
+``` cpp TODO
 #include "mbed.h"
 #include "FlashIAPBlockDevice.h"
 

--- a/docs/api/storage/FlashSimBlockDevice.md
+++ b/docs/api/storage/FlashSimBlockDevice.md
@@ -23,7 +23,7 @@ To configure this class, please see our [BlockDevice configuration documentation
 
 This FlashSimBlockDevice example takes a [HeapBlockDevice](heapblockdevice.html) and turns it into a simulated flash BD.
 
-```C++
+```C++ TODO
     int erase_unit_size = 512;
     HeapBlockDevice heap_bd(4 * erase_unit_size, 1, 4, erase_unit_size);
     FlashSimBlockDevice flash_bd(&heap_bd, blank);

--- a/docs/api/storage/SDBlockDevice.md
+++ b/docs/api/storage/SDBlockDevice.md
@@ -74,7 +74,7 @@ The figure above shows the Mbed OS software component stack used for data storag
 
 The following sample code illustrates how to use the SD block device API:
 
-``` cpp
+``` cpp TODO
 #include "mbed.h"
 #include "SDBlockDevice.h"
 

--- a/docs/api/storage/SPIFBlockDevice.md
+++ b/docs/api/storage/SPIFBlockDevice.md
@@ -14,7 +14,7 @@ To configure this class, please see our [BlockDevice configuration documentation
 
 ### SPIFBlockDevice example
 
-``` cpp
+``` cpp TODO
 // Here's an example using the MX25R SPI flash device on the K82F
 #include "mbed.h"
 #include "SPIFBlockDevice.h"

--- a/docs/api/usb/USBAudio.md
+++ b/docs/api/usb/USBAudio.md
@@ -51,7 +51,7 @@ int main() {
 
 This example loops input audio to the Mbed board back to the host PC, so that you may record the audio or listen to it through headphones or speakers.
 
-```C++
+```C++ TODO
 // Audio loopback example use:
 // 1. Select "Mbed Audio" as your PC's default speaker and microphone devices.
 // 2. Play some sound (YouTube, audio file, etc.) on your PC with Mbed board connected to your PC via the target's USB.

--- a/docs/api/usb/USBAudio.md
+++ b/docs/api/usb/USBAudio.md
@@ -12,7 +12,7 @@ You can use the USBAudio interface to send and receive audio data over USB. Once
 
 This example outputs an audio square wave over USB.
 
-```C++
+```C++ TODO
 // This example simply generates a square wave. 
 // Use a program like Audacity to record and hear the square wave, or route microphone input to output device.
 #include "mbed.h"

--- a/docs/api/usb/USBCDC.md
+++ b/docs/api/usb/USBCDC.md
@@ -10,7 +10,7 @@ The USBCDC class emulates a basic serial port over USB. You can use this serial 
 
 ### USBCDC example
 
-```C++
+```C++ TODO
 #include "mbed.h"
 #include "USBCDC.h"
 

--- a/docs/api/usb/USBHID.md
+++ b/docs/api/usb/USBHID.md
@@ -12,7 +12,7 @@ You can use the USBHID class to turn an Mbed board into an HID (Human Interface 
 
 #### main.cpp   
 
-```C++
+```C++ TODO
 #include "mbed.h"
 #include "USBHID.h"
 

--- a/docs/api/usb/USBKeyboard.md
+++ b/docs/api/usb/USBKeyboard.md
@@ -10,7 +10,7 @@ The USBKeyboard class provides the functionality of a keyboard. You can send key
 
 ### USBKeyboard example
 
-```C++
+```C++ TODO
 #include "mbed.h"
 #include "USBKeyboard.h"
 

--- a/docs/api/usb/USBMIDI.md
+++ b/docs/api/usb/USBMIDI.md
@@ -44,7 +44,7 @@ int main() {
 
 You can use USBMIDI to play an entire song, not just a series of notes. "Take Me Out to the Ball Game" is a popular song in the public domain. To play "Take Me Out to the Ball Game" (public domain) using MIDI over USB on the host PC:
 
-```C++
+```C++ TODO
 #include "mbed.h"
 #include "USBMIDI.h"
 

--- a/docs/api/usb/USBMIDI.md
+++ b/docs/api/usb/USBMIDI.md
@@ -22,7 +22,7 @@ The two examples below use a program called "Anvil Studio 32-bit" to play MIDI n
 
 Below is an example to send a series of MIDI notes to the host PC:    
 
-```C++
+```C++ TODO
 #include "mbed.h"
 #include "USBMIDI.h"
 

--- a/docs/api/usb/USBMSD.md
+++ b/docs/api/usb/USBMSD.md
@@ -10,7 +10,7 @@ You can use the USBMSD interface to emulate a mass storage device over USB. You 
 
 ### USBMSD example
 
-```C++
+```C++ TODO
 #include "mbed.h"
 #include "SDBlockDevice.h"
 #include "USBMSD.h"

--- a/docs/api/usb/USBMouse.md
+++ b/docs/api/usb/USBMouse.md
@@ -11,7 +11,7 @@ If you need keyboard or keyboard and mouse functionality, please see the [USBKey
 
 ### USBMouse example
 
-```C++
+```C++ TODO
 #include "mbed.h"
 #include "USBMouse.h"
 
@@ -39,7 +39,7 @@ int main() {
 
 You can choose either a relative mouse or an absolute mouse. With a relative mouse, the USBMouse move function will move the mouse x, y pixels away from its previous position on the screen. For an absolute mouse, the USBMouse move function will move the mouse to coordinates x, y on the screen. By default, a USBMouse is a relative mouse. For example, you can use an absolute mouse to draw a circle:
 
-```C++
+```C++ TODO
 #include "mbed.h"
 #include "USBMouse.h"
 

--- a/docs/api/usb/USBMouse.md
+++ b/docs/api/usb/USBMouse.md
@@ -78,7 +78,7 @@ int main(void)
 
 This example uses a Grove - Thumb Joystick to act as a mouse. Use the joystick to move the mouse around the screen and click the joystick down to do a mouse left click.
 
-```C++
+```C++ TODO
 //Grove - Thumb Joystick mouse
 //Constructor is blocking, so main will not run if the target's USB is not connected
 #include "mbed.h"

--- a/docs/api/usb/USBMouseKeyboard.md
+++ b/docs/api/usb/USBMouseKeyboard.md
@@ -10,7 +10,7 @@ You can use the USBMouseKeyboard interface to emulate a mouse and a keyboard at 
 
 ### USBMouseKeyboard example
 
-```C++
+```C++ TODO
 //Dual mouse/keyboard device example
 //Example will "type" ASCII characters to the screen, move the mouse around in a circle, and assert various media and modifier keys
 #include "mbed.h"

--- a/docs/api/usb/USBSerial.md
+++ b/docs/api/usb/USBSerial.md
@@ -10,7 +10,7 @@ You can use the USBSerial interface to emulate a serial port over USB. You can u
 
 ### USBSerial example
 
-```C++
+```C++ TODO
 #include "mbed.h"
 #include "USBSerial.h"
 

--- a/docs/porting/connectivity/CellularInterface.md
+++ b/docs/porting/connectivity/CellularInterface.md
@@ -30,12 +30,12 @@ For example,
         "inherits": ["BaseTargetForAll"],
         "device_has": ["ETHERNET", "SPI"],
         "device_name": "NewDevice"
-    },
+    }
 ```
 
 In addition you need to map onboard modem pin aliases to your target board pin names and polarity in `targets/TARGET_FAMILY/YOUR_TARGET/PinNames.h`. If any of the pins are not connected, mark it 'NC'. An example UART configuration:
 
-```C
+```C TODO
 typedef enum {
 
 	MDMTXD = P0_15, // Transmit Data

--- a/docs/porting/connectivity/NetworkStack.md
+++ b/docs/porting/connectivity/NetworkStack.md
@@ -35,7 +35,7 @@ High-level API calls to an implementation of a network-socket API are **identica
 
 Below is a demonstration with the code that sends an HTTP request over Ethernet:
 
-```C++
+```C++ TODO
     EthernetInterface net;
     int return_code = net.connect();
     if (return_code < 0)
@@ -64,14 +64,14 @@ Below is a demonstration with the code that sends an HTTP request over Ethernet:
 
 To change the connectivity to ESP8266 Wi-Fi, change these lines:
 
-```C++
+```C++ TODO
     EthernetInterface net;
     int return_code = net.connect();
 ```
 
 To:
 
-```C++
+```C++ TODO
     ESP8266Interface net(TX_PIN, RX_PIN);
     int return_code = net.connect("my_ssid", "my_password");
 ```
@@ -176,7 +176,7 @@ To send AT commands 1-2, there is an `ESP8266` method called [`startup(int mode)
 
 The necessary code is:
 
-```C++
+```C++ TODO
 
 bool ESP8266::startup(int mode)
 {
@@ -198,7 +198,7 @@ The parser's `send` function returns true if the command succesully sent to the 
 
 So far, our connect method looks something like:
 
-```C++
+```C++ TODO
 int ESP8266Interface::connect()
 {
     if (!_esp.startup(3)) {
@@ -220,7 +220,7 @@ You implemented similar methods to `startup` in ESP8266 to send AT commands 3-5.
 
 The `NetworkStack` parent class dictates that you implement the functionality of opening a socket. This is the method signature in the interface:
 
-```C++
+```C++ TODO
 int ESP8266Interface::socket_open(void **handle, nsapi_protocol_t proto)
 ```
 
@@ -230,7 +230,7 @@ The ESP8266 module can only handle 5 open sockets, so you want to ensure that yo
 
 So far, the method looks like this:
 
-```C++
+```C++ TODO
 int ESP8266Interface::socket_open(void **handle, nsapi_protocol_t proto)
 {
     // Look for an unused socket
@@ -253,7 +253,7 @@ int ESP8266Interface::socket_open(void **handle, nsapi_protocol_t proto)
 
 After you've determined that you have an open socket, you want to store some information in the `handle` parameter. We've created a `struct` to store information about the socket that will be necessary for network operations:
 
-```C++
+```C++ TODO
 struct esp8266_socket {
     int id; // Socket ID number
     nsapi_protocol_t proto; // TCP or UDP
@@ -264,7 +264,7 @@ struct esp8266_socket {
 
 Create one of these, store some information in it and then point the `handle` at it:
 
-```C++
+```C++ TODO
 int ESP8266Interface::socket_open(void **handle, nsapi_protocol_t proto)
 {
     ...
@@ -287,7 +287,7 @@ See the full implementation [here](https://github.com/ARMmbed/esp8266-driver/blo
 
 The `NetworkStack` parent class dictates that you implement the functionality of connecting a socket to a remote server. This is the method signature in the interface:
 
-```C++
+```C++ TODO
 int ESP8266Interface::socket_connect(void *handle, const SocketAddress &addr)
 ```
 
@@ -295,7 +295,7 @@ In this case, the handle is one that has been assigned in the [`socket_open`](ht
 
 You can cast the void pointer to an `esp8266_socket` pointer. Do this in the body of `socket_connect`:
 
-```C++
+```C++ TODO
 int ESP8266Interface::socket_connect(void *handle, const SocketAddress &addr)
 {
     struct esp8266_socket *socket = (struct esp8266_socket *)handle;
@@ -318,7 +318,7 @@ Access the socket ID and socket protocol from the members of `esp8266_socket`. A
 
 This method sends the AT command for opening a socket to the Wi-Fi module and is defined as follows:
 
-```C++
+```C++ TODO
 bool ESP8266::open(const char *type, int id, const char* addr, int port)
 {
     //IDs only 0-4
@@ -337,7 +337,7 @@ In this instance, use the AT command parser to send `AT+CIPSTART=[id],[TCP or UD
 
 The `NetworkStack` parent class dictates that you implement the functionality of registering a callback on state change of the socket. This is the method signature in the interface:
 
-```C++
+```C++ TODO
 void ESP8266Interface::socket_attach(void *handle, void (*callback)(void *), void *data)
 ```
 
@@ -345,7 +345,7 @@ Call the specified callback on state changes, such as when the socket can recv/s
 
 ESP8266 can have up to five open sockets. You need to keep track of all their callbacks. This [struct](https://github.com/ARMmbed/esp8266-driver/blob/master/ESP8266Interface.h#L269-L272) holds the callback as well as the data of these callbacks. It is stored as a private class variable `_cbs`:
 
-```C++
+```C++ TODO
 struct {
     void (*callback)(void *);
     void *data;
@@ -354,7 +354,7 @@ struct {
 
 The attach method is:
 
-```C++
+```C++ TODO
 void ESP8266Interface::socket_attach(void *handle, void (*callback)(void *), void *data)
 {
     struct esp8266_socket *socket = (struct esp8266_socket *)handle;    
@@ -365,7 +365,7 @@ void ESP8266Interface::socket_attach(void *handle, void (*callback)(void *), voi
 
 Store the information in the `_cbs` struct for use on state changes. There is a method `event()` to call socket callbacks. It looks like this:
 
-```C++
+```C++ TODO
 void ESP8266Interface::event() {
     for (int i = 0; i < ESP8266_SOCKET_COUNT; i++) {
         if (_cbs[i].callback) {

--- a/docs/porting/target/entropy.md
+++ b/docs/porting/target/entropy.md
@@ -55,7 +55,7 @@ You have to define a structure `trng_s` that holds all the information needed to
 
 To enable initializing and releasing the peripheral, you must implement the following functions:
 
-```C
+```C NOCI
 void trng_init(trng_t *obj);
 void trng_free(trng_t *obj);
 ```
@@ -64,7 +64,7 @@ void trng_free(trng_t *obj);
 
 The function `trng_get_bytes()` serves as the primary interface to the entropy source. It is expected to load the collected entropy to the buffer and is declared as follows:
 
-```C
+```C NOCI
 int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_length);
 ```
 
@@ -112,7 +112,7 @@ The NV seed entropy source needs to know how to retrieve and store the seed in n
 
 The relevant read/write functions have the following prototypes:
 
-``` C
+``` C NOCI
 int (*mbedtls_nv_seed_read)( unsigned char *buf, size_t buf_len );
 int (*mbedtls_nv_seed_write)( unsigned char *buf, size_t buf_len );
 ```

--- a/docs/porting/tools/build.md
+++ b/docs/porting/tools/build.md
@@ -31,7 +31,7 @@ class LPCTargetCode(object):
 A target that needs this postbuild script run must contain this snippet in `targets/targets.json`:
 
 ```JSON
-"post_binary_hook": {"function": "LPCTargetCode.lpc_patch"},
+"post_binary_hook": {"function": "LPCTargetCode.lpc_patch"}
 ```
 
 When implementing a postbuild script, please be aware of the following considerations:

--- a/docs/reference/api/usb/Audio_Play_Sound_Data.md
+++ b/docs/reference/api/usb/Audio_Play_Sound_Data.md
@@ -1,3 +1,4 @@
+``` cpp
 #include "mbed.h"
 #include "USBAudio.h"
 
@@ -9386,3 +9387,4 @@ int main() {
         audio.write((uint8_t*)data, NUM_ELEMENTS * 2);
     }
 }
+```

--- a/docs/reference/api/usb/Audio_Play_Sound_Data.md
+++ b/docs/reference/api/usb/Audio_Play_Sound_Data.md
@@ -1,4 +1,4 @@
-``` cpp
+``` cpp TODO
 #include "mbed.h"
 #include "USBAudio.h"
 

--- a/docs/reference/configuration/configuration.md
+++ b/docs/reference/configuration/configuration.md
@@ -61,7 +61,7 @@ Name: configuration-store.storage_disable
 
 When compiling or exporting, the configuration system generates C preprocessor macro definitions of the configuration parameters. The configuration system writes these definitions in a file named `mbed_config.h` located in the build directory. When compiling the same example as the prior section for target `K64F`, the `mbed_config.h` file includes this snippet (note that the order of the definitions may be different):
 
-```C
+```C NOCI
 // Automatically generated configuration file.
 // DO NOT EDIT, content will be overwritten.
 

--- a/docs/reference/contributing/guidelines/style.md
+++ b/docs/reference/contributing/guidelines/style.md
@@ -26,7 +26,7 @@ File `.astylerc` defines Mbed OS code style and it's located in Mbed OS root dir
 
 #### Code sample
 
-```c
+```c TODO
 static const PinMap PinMap_ADC[] = {
     {PTC2, ADC0_SE4b, 0},
     {NC , NC , 0}
@@ -123,8 +123,8 @@ uint32_t adc_function(analogin_t *obj, uint32_t options)
 
 As an example:
 
-```c
-#define ADC_INSTANCE_SHIFT 8 
+```cPP TODO
+#define ADC_INSTANCE_SHIFT 8
 
 class AnalogIn {
 public:

--- a/docs/reference/technology/USB.md
+++ b/docs/reference/technology/USB.md
@@ -22,7 +22,7 @@ The recommended model for synchronizing a USB component is to wrap code requirin
 
 Code requiring locking:
 
-```c
+```c TODO
 void USBComponent::do_something()
 {
     lock();
@@ -35,7 +35,7 @@ void USBComponent::do_something()
 
 Code that expects a caller at a higher level to hold the lock:
 
-```c
+```c TODO
 void USBComponent::do_something_internal()
 {
     assert_locked();
@@ -95,7 +95,7 @@ To ensure a USB component runs on all supported devices, the USB component must 
 
 To simplify the process of selecting endpoints, we recommend you use the EndpointResolver class. A USB component constructs the class with an endpoint table. The USB component can then call the class to find an endpoint of the given type and size. After the component finds all required endpoints, it can call the function `EndpointResolver::valid()` to determine whether this device supports this configuration. Below is an example of this:
 
-```c++
+```c++ TODO
 EndpointResolver resolver(endpoint_table());
 resolver.endpoint_ctrl(CDC_MAX_PACKET_SIZE);
 bulk_in = resolver.endpoint_in(USB_EP_TYPE_BULK, CDC_MAX_PACKET_SIZE);

--- a/docs/reference/technology/connectivity/lora-tech.md
+++ b/docs/reference/technology/connectivity/lora-tech.md
@@ -131,7 +131,7 @@ The LoRa radio drivers support both RTOS and non-RTOS environments. For RTOS env
 
 The application constructs the `LoRaRadio` object and passes it down to the stack:
 
-```C
+```C TODO
 SX1272_LoRaRadio radio(PIN_NAMES,...);
 LoRaWANInterface lorawan(radio);
 ```
@@ -140,7 +140,7 @@ LoRaWANInterface lorawan(radio);
 
 The stack sets callbacks in `radio_events_t` structure and provides these callbacks to the radio driver:
 
-```C
+```C TODO
 // setting up callbakcs in radio_events_t
 radio_events.tx_done = mbed::callback(this, &LoRaWANStack::tx_interrupt_handler);
 radio_events.rx_done = mbed::callback(this, &LoRaWANStack::rx_interrupt_handler);
@@ -159,7 +159,7 @@ radio.unlock();
 
 The radio driver uses the callbacks it received in the form `radio_events_t` to notify the the upper layers to postprocess an interrupt.
 
-```C
+```C NOCI
 if (signal & GENERATE_TX_DONE) {
 	radio_events->tx_done();
 }
@@ -204,15 +204,14 @@ The implementations of the `LoRaPHY` declare these parameters in a structure whi
 At the moment, it's not possible to change a PHY during run time. You must select a PHY layer before compiling the application using the Mbed configuration system:
 
 ```json
-
 "target_overrides": {
-	 "*": {
-	 	"lora.phy": {
-	 		"help": "LoRa PHY region: EU868, AS923, AU915, 	CN470, CN779, EU433, IN865, KR920, US915, US915_HYBRID",
-	 		"value": "EU868"
-	 		}
-	    }
- }
+    "*": {
+        "lora.phy": {
+            "help": "LoRa PHY region: EU868, AS923, AU915, CN470, CN779, EU433, IN865, KR920, US915, US915_HYBRID",
+            "value": "EU868"
+        }
+    }
+}
 ```
 ##### EventQueue
 
@@ -232,7 +231,7 @@ The Arm Mbed LoRaWAN stack sends a `CONNECTED` event to the application once the
 
 For a detailed API reference for outgoing messages, please visit the [LoRaWANInterface API documentation](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_lo_ra_w_a_n_interface.html). Look for `send()` API. For example:
 
-```C
+```C NOCI
 /**send an Unconfirmed message*/
 lorawan.send(port, data, length, MSG_UNCONFIRMED_FLAG);
 ```
@@ -255,7 +254,7 @@ For detailed API reference for outgoing messages, please visit the [LoRaWANInter
 
 There are two types of `receive()` methods in the stack. The first is POSIX-like, and you need to tell at what port (instead of a socket ID in Posix format) you wish to receive:
 
-```C
+```C NOCI
 
 /**this means receive any confirmed or unconfirmed message at port my_port*/
 lorawan.receive(my_port, buffer, length, MSG_UNCONFIRMED|MSG_CONFIRMED_FLAG);

--- a/docs/tools/IDE/how_to_document.md
+++ b/docs/tools/IDE/how_to_document.md
@@ -46,7 +46,7 @@ The documentation is created out of comment blocks in your code, usually located
 class HelloWorld {
 	public:
 		HelloWorld();
-		printIt(uint32_t delay = 0);
+		void printIt(uint32_t delay = 0);
 };
 ```
 
@@ -68,7 +68,7 @@ class HelloWorld {
 		HelloWorld();
 
 		/** Print the text */
-		printIt(uint32_t delay = 0);
+		void printIt(uint32_t delay = 0);
 };
 ```
 
@@ -82,7 +82,7 @@ class HelloWorld {
 	HelloWorld();
 
 	/// Print the text
-	printIt(uint32_t delay = 0);
+	void printIt(uint32_t delay = 0);
 };
 ```
 
@@ -137,7 +137,7 @@ class HelloWorld {
 		*   1 on success,
 		*   0 on serial error
 		*/
-		printIt(uint32_t delay = 0);
+		void printIt(uint32_t delay = 0);
 };
 ```
 

--- a/docs/tools/mbed_targets.md
+++ b/docs/tools/mbed_targets.md
@@ -145,7 +145,7 @@ The list of _configs_ provide a way to modify the values of macros in child targ
 "config": {
     "clock_src": {
         "help": "Clock source to use, can be XTAL or RC",
-        "value": "XTAL",
+        "value": "XTAL"
     },
     "clock_freq": {
         "help": "Clock frequency in Mhz",

--- a/docs/tools/testing/testing_greentea.md
+++ b/docs/tools/testing/testing_greentea.md
@@ -79,7 +79,7 @@ The Greentea tool handles the actual testing process. To read more about this to
 
 You can write tests for your own project or add more tests to Mbed OS. You can write tests by using the [Greentea client](https://github.com/ARMmbed/mbed-os/tree/master/features/frameworks/greentea-client), and the [UNITY](https://github.com/ARMmbed/mbed-os/tree/master/features/frameworks/unity) and [utest](https://github.com/ARMmbed/mbed-os/tree/master/features/frameworks/utest) frameworks, which are located in `/features/frameworks`. Below is an example test that uses all of these frameworks:
 
-```c++
+```c++ TODO
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/docs/tools/testing/utest.md
+++ b/docs/tools/testing/utest.md
@@ -23,7 +23,7 @@ The order of handler execution is:
 
 This example showcases functionality and proper integration with the [Greentea testing automation framework](greentea-testing-applications.html), while making use of the [unity test macros](https://github.com/ARMmbed/mbed-os/tree/master/features/frameworks/unity):
 
-```cpp
+```cpp TODO
 #include "greentea-client/test_env.h"
 #include "unity.h"
 #include "utest.h"

--- a/docs/tools/testing/utest.md
+++ b/docs/tools/testing/utest.md
@@ -27,6 +27,7 @@ This example showcases functionality and proper integration with the [Greentea t
 #include "greentea-client/test_env.h"
 #include "unity.h"
 #include "utest.h"
+```
 
 using namespace utest::v1;
 
@@ -226,7 +227,7 @@ These default handlers are called when you have not overridden a custom handler,
 
 You can specify which default handlers you want to use when wrapping your test cases in the `Specification` class:
 
-```cpp
+```cpp TODO
 // Declare your test specification with a custom setup handler
 // and set the default handlers to the predefined “greentea continue” behavior
 Specification specification(greentea_setup, cases, greentea_continue_handlers);
@@ -294,7 +295,7 @@ There are two functions you need to implement:
 
 Here is the most basic scheduler implementation without any asynchronous support. Note that this does not require any hardware support at all, but you cannot use timeouts in your test cases.
 
-```cpp
+```cpp TODO
 volatile utest_v1_harness_callback_t minimal_callback;
 
 static void* utest_minimal_post(const utest_v1_harness_callback_t callback, const uint32_t delay_ms) {
@@ -330,7 +331,7 @@ void main() // or whatever your custom entry point is
 
 Here is the complete scheduler implementation with any asynchronous support. Note that this does require at least a hardware timer. This example uses `mbed-hal/us_ticker`. Note that you must not execute the callback in the timer interrupt context, but in the main loop context.
 
-```cpp
+```cpp TODO
 volatile utest_v1_harness_callback_t minimal_callback;
 volatile utest_v1_harness_callback_t ticker_callback;
 const ticker_data_t *ticker_data;

--- a/docs/tutorials/debug/debug_with_printf.md
+++ b/docs/tutorials/debug/debug_with_printf.md
@@ -198,7 +198,7 @@ The general form for defining a parameterized macro is:
 
 ```
 #define MACRO_NAME(param1, param2, ...)
-	{body-of-macro}
+    {body-of-macro}
 ```
 
 For example, you can categorize `printf()` statements by severity levels, such as `DEBUG`, `WARNING` and `ERROR`. To do so, define levels of severity. Then, each time you compile or run the program, specify which level you want to use. The macros use the level you specified in an `if` condition. That condition can control the format of the information the macro prints, or whether it prints anything at all. This gives you full control of the debug information presented every run.
@@ -207,11 +207,11 @@ Remember that `printf()` can take as many parameters as you give it. Macros supp
 
 This is an example:
 
-```c
+```c 
 // -- within a header file named something like trace.h --
 enum {
-	TRACE_LEVEL_DEBUG,
-	TRACE_LEVEL_WARNING
+    TRACE_LEVEL_DEBUG,
+    TRACE_LEVEL_WARNING
 };
 /* each time we compile or run the program,
 * we determine what the trace level is.
@@ -220,41 +220,41 @@ enum {
 
 extern unsigned traceLevel;
 
-...
+// ...
 
 // Our first macro prints if the trace level we selected
 // is TRACE_LEVEL_DEBUG or above.
 // The traceLevel is used in the condition
 // and the regular parameters are used in the action that follows the IF
 #define TRACE_DEBUG(formatstring, parameter1, parameter2, ...) \
-	{ if (traceLevel >= TRACE_LEVEL_DEBUG) \
-			{ printf("-D- " formatstring, __VA_ARGS__); } }
+    { if (traceLevel >= TRACE_LEVEL_DEBUG) \
+            { printf("-D- " formatstring, __VA_ARGS__); } }
 // this will include the parameters we passed above
 
 // we create a different macro for each trace level
 #define TRACE_WARNING(formatstring, parameter1, parameter2, ...) \
-	{ if (traceLevel >= TRACE_LEVEL_WARNING) \
-		{ printf("-W- " formatstring, __VA_ARGS__); } }
+    { if (traceLevel >= TRACE_LEVEL_WARNING) \
+        { printf("-W- " formatstring, __VA_ARGS__); } }
 ```
 
 This is another example of macro-replacement that allows a formatted `printf()`. Set `#define MODULE_NAME "<YourModuleName>"` before including the code below, and enjoy colorized `printf()` tagged with the module name that generated it:
 
 ```c
 #define LOG(x, ...) \
-	{ printf("\x1b[34m%12.12s: \x1b[39m"x"\x1b[39;49m\r\n", \
-	MODULE_NAME, ##__VA_ARGS__); fflush(stdout); }
+    { printf("\x1b[34m%12.12s: \x1b[39m"x"\x1b[39;49m\r\n", \
+    MODULE_NAME, ##__VA_ARGS__); fflush(stdout); }
 #define WARN(x, ...) \
-	{ printf("\x1b[34m%12.12s: \x1b[33m"x"\x1b[39;49m\r\n", \
-	MODULE_NAME, ##__VA_ARGS__); fflush(stdout); }
+    { printf("\x1b[34m%12.12s: \x1b[33m"x"\x1b[39;49m\r\n", \
+    MODULE_NAME, ##__VA_ARGS__); fflush(stdout); }
 ```
 
 You can use `ASSERT()` to improve error reporting. It uses `error()` (a part of Arm Mbed OS). `error()` flashes LEDs and puts the program into an infinite loop, preventing further operations. This happens if the `ASSERT()` condition is evaluated as FALSE:
 
 ```c
-#define ASSERT(condition, ...)	{ \
-	if (!(condition))	{ \
-		error("Assert: " __VA_ARGS__); \
-	} }
+#define ASSERT(condition, ...)  { \
+    if (!(condition))   { \
+        error("Assert: " __VA_ARGS__); \
+    } }
 ```
 
 ### Fast circular log buffers based on printf()
@@ -267,56 +267,56 @@ To avoid pushing during the operation’s run, use `sprintf()` to write the log 
 
 This is an example implementation of a ring buffer, which wraps `printf()` using a macro called `xprintf()`. Debug messages accumulated using `xprintf()` can be read circularly starting from `ringBufferTail` and wrapping around (`ringBufferTail` + `HALF_BUFFER_SIZE`). An overwrite by the most recently appended message may garble the first message:
 
-```c
+```c TODO
 #define BUFFER_SIZE 512 /* You need to choose a suitable value here. */
 #define HALF_BUFFER_SIZE (BUFFER_SIZE >> 1)
 
 /* Here's one way of allocating the ring buffer. */
 char ringBuffer[BUFFER_SIZE];
 char *ringBufferStart = ringBuffer;
-char *ringBufferTail  = ringBuffer;
+char *ringBufferTail  = ringBuffer;
 
 void xprintf(const char *format, ...)
 {
-	va_list args;
-	va_start(args, format);
-	size_t largestWritePossible =
-			BUFFER_SIZE - (ringBufferTail - ringBufferStart);
-	int written =
-			vsnprintf(ringBufferTail, largestWritePossible, format, args);
-	va_end(args);
+    va_list args;
+    va_start(args, format);
+    size_t largestWritePossible =
+            BUFFER_SIZE - (ringBufferTail - ringBufferStart);
+    int written =
+            vsnprintf(ringBufferTail, largestWritePossible, format, args);
+    va_end(args);
 
-	if (written < 0) {
-		/* do some error handling */
-		return;
-	}
+    if (written < 0) {
+        /* do some error handling */
+        return;
+    }
 
-	/*
-	* vsnprintf() doesn't write more than 'largestWritePossible' bytes to the
-	* ring buffer (including the terminating null byte '\0'). If the output is
-	* truncated due to this limit, then the return value ('written') is the
-	* number of characters (excluding the terminating null byte) which would
-	* have been written to the final string if enough space had been available.
-	*/
+    /*
+    * vsnprintf() doesn't write more than 'largestWritePossible' bytes to the
+    * ring buffer (including the terminating null byte '\0'). If the output is
+    * truncated due to this limit, then the return value ('written') is the
+    * number of characters (excluding the terminating null byte) which would
+    * have been written to the final string if enough space had been available.
+    */
 
-	if (written > largestWritePossible) {
-		/* There are no easy solutions to tackle this. It
-		* may be easiest to enlarge
-		* your BUFFER_SIZE to avoid this. */
-		return; /* this is a short-cut; you may want to do something else.*/
-	}
+    if (written > largestWritePossible) {
+        /* There are no easy solutions to tackle this. It
+        * may be easiest to enlarge
+        * your BUFFER_SIZE to avoid this. */
+        return; /* this is a short-cut; you may want to do something else.*/
+    }
 
-	ringBufferTail += written;
+    ringBufferTail += written;
 
-	/* Is it time to wrap around? */
-	if (ringBufferTail > (ringBufferStart + HALF_BUFFER_SIZE)) {
-		size_t overflow =
-			ringBufferTail - (ringBufferStart + HALF_BUFFER_SIZE);
-			memmove(ringBufferStart, ringBufferStart
-					+ HALF_BUFFER_SIZE, overflow);
-		ringBufferTail =
-					ringBufferStart + overflow;
-	}
+    /* Is it time to wrap around? */
+    if (ringBufferTail > (ringBufferStart + HALF_BUFFER_SIZE)) {
+        size_t overflow =
+            ringBufferTail - (ringBufferStart + HALF_BUFFER_SIZE);
+            memmove(ringBufferStart, ringBufferStart
+                    + HALF_BUFFER_SIZE, overflow);
+        ringBufferTail =
+                    ringBufferStart + overflow;
+    }
 }
 ```
 

--- a/docs/tutorials/serial/serial_communication.md
+++ b/docs/tutorials/serial/serial_communication.md
@@ -15,7 +15,7 @@ This allows you to:
 This program prints a "Hello World" message that you can view on a [terminal application](#terminal-applications). Communication over the USB serial port uses the standard serial interface. Specify the internal (USBTX, USBRX) pins to connect to the serial port routed over USB:
 
 
-```c
+```cpp
 #include "mbed.h"
 
 Serial pc(USBTX, USBRX); // tx, rx
@@ -70,7 +70,7 @@ If you're not sure how to build these examples and run them on your board, pleas
 
 #### Echo back characters you type
 
-```c
+```cpp
 #include "mbed.h"
 
 Serial pc(USBTX, USBRX);
@@ -89,7 +89,7 @@ int main() {
 
 <span class="images">![](https://s3-us-west-2.amazonaws.com/mbed-os-docs-images/NUCLEOF401RE.png)<span>The pin map of the NUCLEO-F401RE shows LED1 on the Pwm pin.</span></span>
 
-```c
+```cpp
 #include "mbed.h"
 
 Serial pc(USBTX, USBRX); // tx, rx
@@ -118,11 +118,11 @@ int main() {
 
 Tie pins together to see characters echoed back.
 
-```c
+```cpp
 #include "mbed.h"
 
 Serial pc(USBTX, USBRX);
-Serial uart(p28, p27);
+Serial uart(D1, D0);
 
 DigitalOut pc_activity(LED1);
 DigitalOut uart_activity(LED2);
@@ -145,7 +145,7 @@ int main() {
 
 By default, the C `stdin`, `stdout` and `stderr file` handles map to the PC serial connection:
 
-```c
+```cpp
 #include "mbed.h"
 
 int main() {
@@ -156,7 +156,7 @@ int main() {
 
 #### Read to a buffer
 
-```c
+```cpp
 #include "mbed.h"
 
 DigitalOut myled(LED1);

--- a/docs/tutorials/using_apis/connectivity/cellular_tcp.md
+++ b/docs/tutorials/using_apis/connectivity/cellular_tcp.md
@@ -2,7 +2,7 @@
 
 This example opens a TCP socket with an echo server and performs a TCP transaction.
 
-```cpp
+```cpp TODO
 #include "mbed.h"
 #include "UDPSocket.h"
 #include "OnboardCellularInterface.h"

--- a/docs/tutorials/using_apis/intro-to-lora.md
+++ b/docs/tutorials/using_apis/intro-to-lora.md
@@ -278,7 +278,7 @@ To send the current value of the PIR sensor (whether it sees movement), in the O
 1. Open `main.cpp`.
 1. Replace the function `send_message()` with:
 
-    ```cpp
+    ```cpp TODO
     static void send_message() {
         static InterruptIn pir(D5); // If you hooked the sensor up to a different pin, change it here
 
@@ -317,7 +317,7 @@ Now you can verify whether the setup works by flashing this application to your 
 
 By default, the application sends data automatically. If you want to change this, remove this line from `main.cpp`:
 
-```cpp
+```cpp NOCI
 ev_queue.call_every(TX_TIMER, send_message);
 ```
 
@@ -332,7 +332,7 @@ You can toggle the LED on your development board over LoRa. In the Online Compil
 1. Open `main.cpp`.
 1. Replace the `receive_message` function with:
 
-    ```cpp
+    ```cpp TODO
     static void receive_message() {
         static DigitalOut led(LED1, 0); // the LED under control, default value of 0
 


### PR DESCRIPTION
Added a little script in travis to compile/validate any c/c++/json code snippets.

There were a few hickups with target specific blobs, so I also parse out an optional target to use for compilation (defaults to K64F). Or, you can simply put either NOCI or TODO to opt out of validation.

cc @iriark01, @AnotherButler, @SenRamakri, @kegilbert 
replaces https://github.com/ARMmbed/mbed-os-5-docs/pull/246