### PR TITLE
Kernel documentation updated with new additions to Kernel namespace

### DIFF
--- a/docs/api/rtos/Kernel.md
+++ b/docs/api/rtos/Kernel.md
@@ -34,6 +34,6 @@ The function `attach_idle_hook()` can be used to attach a function to be called 
 
 ### `attach_thread_terminate_hook()` example
 
-The function `attach_thread_terminate_hook()` can be used to attach a function to be called when a thread is killed
+The function `attach_thread_terminate_hook()` can be used to attach a function to be called when a thread terminates.
 
 [![View Example](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-example-kernel-hooks)](https://github.com/ARMmbed/mbed-os-example-kernel-hooks/blob/master/main.cpp)

--- a/docs/api/rtos/Kernel.md
+++ b/docs/api/rtos/Kernel.md
@@ -1,6 +1,6 @@
 ## Kernel interface functions
 
-The Kernel namespace implements functions to read RTOS information. Currently it implements one function to read the current RTOS kernel millisecond tick count.
+The Kernel namespace implements interfaces to attach a function to some kernel events and also to read the kernel tick count.
 
 ### Kernel namespace reference
 
@@ -8,7 +8,7 @@ The Kernel namespace implements functions to read RTOS information. Currently it
 
 ### `get_ms_count()` example
 
-Kernel implements one function named `get_ms_count()` to read the current RTOS kernel millisecond tick count. The below code snippet demonstrates use of the `get_ms_count()` function to calculate the elapsed time:
+The function `get_ms_count()` can be used to read the current RTOS kernel millisecond tick count. The below code snippet demonstrates use of the `get_ms_count()` function to calculate the elapsed time:
 
 ```
 void send_data()
@@ -23,4 +23,17 @@ void send_data()
     //calculate millisecs elapsed
     uint64_t elapsed_ms = later - now;
 }
+
 ```
+
+### `attach_idle_hook()` example
+
+The function `attach_idle_hook()` can be used to attach a function to be called by the RTOS idle task. The below code snippet demostrates the usage.
+
+[![View Example](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-example-kernel-hooks)](https://github.com/ARMmbed/mbed-os-example-kernel-hooks/blob/master/main.cpp)
+
+### `attach_thread_terminate_hook()` example
+
+The function `attach_thread_terminate_hook()` can be used to attach a function to be called when a thread is killed
+
+[![View Example](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-example-kernel-hooks)](https://github.com/ARMmbed/mbed-os-example-kernel-hooks/blob/master/main.cpp)


### PR DESCRIPTION
Kernel documentation updated with new additions to Kernel namespace:

A new example has been created as well: https://github.com/ARMmbed/mbed-os-example-kernel-hooks
