### PR TITLE
Clarify NetworkStack porting guide

### DIFF
--- a/docs/porting/connectivity/NetworkStack.md
+++ b/docs/porting/connectivity/NetworkStack.md
@@ -1,17 +1,16 @@
 ## NetworkStack
 
-As explained in the [IP networking architecture](../reference/ip-networking.html) page,
-the [Socket API](../apis/network-socket.html) provides a TCP or UDP API on top of any IP based network stack. With the Socket API, you can write applications and libraries that use TCP or UDP sockets without regard to the type of IP connectivity. In addition to providing the TCP or UDP API, the Socket API includes virtual base classes for the different IP interface types.
+As explained in the [IP networking architecture](../architecture/ip-networking.html) page, the [Socket API](../apis/network-socket.html) provides a TCP or UDP API on top of any IP based network stack. With the Socket API, you can write applications and libraries that use TCP or UDP sockets without regard to the type of IP connectivity. In addition to providing the TCP or UDP API, the Socket API includes virtual base classes for the different IP interface types.
 
 In Mbed OS, the network stack can be either inside the connectivity module or inside the software stack Mbed OS provides. This page includes a porting guide for devices that provide external IP stacks. Usually, these are AT-command driven modules.
 
-Please study the [network connectivity](../reference/connectivity-stacks.html) pages from the architecture section before you start porting.
+Please study the [network connectivity](../architecture/connectivity-stacks.html) pages from the architecture section before you start porting.
 
 ### Class hierarchy
 
 Drivers for devices that contain the IP stack inherit from two classes: a [NetworkStack](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_network_stack.html) and a communication-specific subclass of [NetworkInterface](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_network_interface.html).
 
-Please refer to the [IP networking architecture](../reference/ip-networking.html) for device types.
+Please refer to the [IP networking architecture](../architecture/ip-networking.html) for device types.
 
 #### NetworkInterface Class
 

--- a/docs/porting/connectivity/NetworkStack.md
+++ b/docs/porting/connectivity/NetworkStack.md
@@ -1,17 +1,17 @@
 ## NetworkStack
 
-As explained in [IP Networking architecture](../reference/ip-networking.html) page,
-the [Socket API](../apis/network-socket.html) provides a TCP/UDP API on top of any IP based network stack. With the Socket API, you can write applications and libraries that use TCP/UDP Sockets without regard to the type of IP connectivity. In addition to providing the TCP/UDP API, the Socket API includes virtual base classes for the different IP interface types.
+As explained in the [IP networking architecture](../reference/ip-networking.html) page,
+the [Socket API](../apis/network-socket.html) provides a TCP or UDP API on top of any IP based network stack. With the Socket API, you can write applications and libraries that use TCP or UDP sockets without regard to the type of IP connectivity. In addition to providing the TCP or UDP API, the Socket API includes virtual base classes for the different IP interface types.
 
-In Mbed OS, the actual network stack can be inside of the connectivity module, or software stack provided by Mbed OS. This page provides you a porting guide for these devices that provide external IP stacks. Usually these are AT-command driven modules.
+In Mbed OS, the network stack can be either inside the connectivity module or inside the software stack Mbed OS provides. This page includes a porting guide for devices that provide external IP stacks. Usually, these are AT-command driven modules.
 
-Please study the [Network Connectivity](../reference/connectivity-stacks.html) pages from architecture section before starting the porting work.
+Please study the [network connectivity](../reference/connectivity-stacks.html) pages from the architecture section before you start porting.
 
 ### Class hierarchy
 
-Driver for devices that contain IP stack inherit from two classes: a [NetworkStack](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_network_stack.html) and a communication specific subclass of [NetworkInterface](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_network_interface.html).
+Drivers for devices that contain the IP stack inherit from two classes: a [NetworkStack](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_network_stack.html) and a communication-specific subclass of [NetworkInterface](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_network_interface.html).
 
-Refer to the [IP Networking architecture](../reference/ip-networking.html) for device types.
+Please refer to the [IP networking architecture](../reference/ip-networking.html) for device types.
 
 #### NetworkInterface Class
 
@@ -34,13 +34,13 @@ Each subclass has distinct pure virtual methods. Visit their class references (l
 
 #### Errors
 
-Many functions of `NetworkStack` and `NetworkInterface` have return types of `nsapi_error_t`, which is a type used to represent error codes. You can see a list of these return codes [here](https://os.mbed.com/docs/v5.10/mbed-os-api-doxy/group__netsocket.html#gac21eb8156cf9af198349069cdc7afeba). You can view the integer values the error macros in [this file](https://github.com/ARMmbed/mbed-os/blob/master/features/netsocket/nsapi_types.h). A negative error code indicates failure, while 0 indicates success.
+Many functions of `NetworkStack` and `NetworkInterface` have return types of `nsapi_error_t`, which is a type used to represent error codes. You can see a [list of these return codes](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__netsocket.html#gac21eb8156cf9af198349069cdc7afeba). You can view the [integer values of the error macros](https://github.com/ARMmbed/mbed-os/blob/master/features/netsocket/nsapi_types.h). A negative error code indicates failure, and 0 indicates success.
 
 #### The `connect()` method
 
-High-level API calls to an implementation of a network-socket API are **identical** across networking protocols. The only difference is the interface object constructor and the method through which you connect to the network. For example, a Wi-Fi connection requires an SSID and password, a cellular connection requires an APN and Ethernet doesn't require any credentials. Each interface type may provide overloaded `connect()` method with required parameters, but it is preferred to offer these parameters as a configuration values to allow network interfaces to be changed just by changing configuration file.
+High-level API calls to an implementation of a network-socket API are **identical** across networking protocols. The only difference is the interface object constructor and the method through which you connect to the network. For example, a Wi-Fi connection requires an SSID and password, a cellular connection requires an APN and Ethernet doesn't require any credentials. Each interface type may provide an overloaded `connect()` method with required parameters, but the preferred method is to offer these parameters as configuration values to allow the changing of network interfaces by changing a configuration file.
 
-Below is a demonstration with the code that connects to a network and relies that required configuration are provided:
+Below is a demonstration with the code that connects to a network and relies on the required provided configuration:
 
 ```C++ NOCI
     NetworkInterface *net = NetworkInterface::get_default_instance();
@@ -49,11 +49,11 @@ Below is a demonstration with the code that connects to a network and relies tha
         printf("Error connecting to network %d\r\n", return_code);
 ```
 
-To change the example to use other network interfaces or provide configuration values for WiFi or other types, see [Network interface: Default network interface](../apis/network-interfaces.html)
+To change the example to use other network interfaces or provide configuration values for Wi-Fi or other types, please see [the default network interface](../apis/network-interfaces.html).
 
-#### Providing Socket API
+#### Providing the Socket API
 
-`NetworkStack` must implement following API in order to support TCP/UDP sockets:
+`NetworkStack` must implement the following API in order to support TCP or UDP sockets:
 
 ```C++ NOCI
 nsapi_error_t socket_open(nsapi_socket_t *handle, nsapi_protocol_t proto);
@@ -70,20 +70,19 @@ nsapi_error_t setsockopt(nsapi_socket_t handle, int level, int optname, const vo
 nsapi_error_t getsockopt(nsapi_socket_t handle, int level, int optname, void *optval, unsigned *optlen);
 ```
 
-Please note that as the blocking operation mode of Socket is provided by higher level Socket API, the underlying calls to `NetworkStack` object should not block. This forces some network operations to be done in separate worker thread or in shared event queue. Any calls to these functions should return `NSAPI_ERROR_WOULD_BLOCK` in case the operation cannot be immediately completed.
+Please note that as the blocking operation mode of Socket is provided by higher level Socket API, the underlying calls to `NetworkStack` object should not block. This forces some network operations to occur in a separate worker thread or in a shared event queue. Any calls to these functions should return `NSAPI_ERROR_WOULD_BLOCK` in case the operation cannot be immediately completed.
 
-Refer to the Doxygen documentation of [NetworkStack](../mbed-os-api-doxy/class_network_stack.html) for API descriptions.
+Please refer to the Doxygen documentation of [NetworkStack](../mbed-os-api-doxy/class_network_stack.html) for API descriptions.
 
 ### Testing
 
-To test new `NetworkStack` implementations full set of Mbed OS socket tests should be run.
+To test new `NetworkStack` implementations, run the full set of Mbed OS socket tests.
 
-Follow the guide from [Network Socket test plan](https://github.com/ARMmbed/mbed-os/blob/master/TESTS/netsocket/README.md).
+Follow the guide from the [Network Socket test plan](https://github.com/ARMmbed/mbed-os/blob/master/TESTS/netsocket/README.md).
 
-Building and running the tests require you to provide the `mbed_app.json` as guided, and run the test with `mbed test -n mbed-os-tests-network-*,mbed-os-tests-netsocket*`
+Building and running the tests require you to provide the `mbed_app.json` as guided, and run the test with `mbed test -n mbed-os-tests-network-*,mbed-os-tests-netsocket*`.
 
-
-### Case Study: ESP8266 Wi-Fi component
+### Case study: ESP8266 Wi-Fi component
 
 This example ports a driver for the ESP8266 Wi-Fi module to the NSAPI.
 

--- a/docs/porting/connectivity/NetworkStack.md
+++ b/docs/porting/connectivity/NetworkStack.md
@@ -1,10 +1,17 @@
 ## NetworkStack
 
-The Network-Socket-API (NSAPI) provides a TCP/UDP API on top of any IP based network interface. With the NSAPI, you can write applications and libraries that use TCP/UDP Sockets without regard to the type of IP connectivity. In addition to providing the TCP/UDP API, the NSAPI includes virtual base classes for the different IP interface types.
+As explained in [IP Networking architecture](../reference/ip-networking.html) page,
+the [Socket API](../apis/network-socket.html) provides a TCP/UDP API on top of any IP based network stack. With the Socket API, you can write applications and libraries that use TCP/UDP Sockets without regard to the type of IP connectivity. In addition to providing the TCP/UDP API, the Socket API includes virtual base classes for the different IP interface types.
+
+In Mbed OS, the actual network stack can be inside of the connectivity module, or software stack provided by Mbed OS. This page provides you a porting guide for these devices that provide external IP stacks. Usually these are AT-command driven modules.
+
+Please study the [Network Connectivity](../reference/connectivity-stacks.html) pages from architecture section before starting the porting work.
 
 ### Class hierarchy
 
-All network-socket API implementations inherit from two classes: a [NetworkStack](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_network_stack.html) and a communication specific subclass of [NetworkInterface](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_network_interface.html).
+Driver for devices that contain IP stack inherit from two classes: a [NetworkStack](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_network_stack.html) and a communication specific subclass of [NetworkInterface](https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_network_interface.html).
+
+Refer to the [IP Networking architecture](../reference/ip-networking.html) for device types.
 
 #### NetworkInterface Class
 
@@ -25,106 +32,56 @@ Each subclass has distinct pure virtual methods. Visit their class references (l
 
 `NetworkStack` provides [these functions](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/class_network_stack.html). Look for the function signature like [`declarator virt-specifier(optional) = 0`](http://en.cppreference.com/w/cpp/language/abstract_class) to determine which functions are pure virtual and which you must override in your child class.
 
-### Errors
+#### Errors
 
-Many functions of `NetworkStack` and `NetworkInterface` have return types of `nsapi_error_t`, which is a type used to represent error codes. You can see a list of these return codes [here](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.4/api/group__netsocket.html#gac21eb8156cf9af198349069cdc7afeba). You can view the integer values the error macros in [this file](https://github.com/ARMmbed/mbed-os/blob/master/features/netsocket/nsapi_types.h). A negative error code indicates failure, while 0 indicates success.
+Many functions of `NetworkStack` and `NetworkInterface` have return types of `nsapi_error_t`, which is a type used to represent error codes. You can see a list of these return codes [here](https://os.mbed.com/docs/v5.10/mbed-os-api-doxy/group__netsocket.html#gac21eb8156cf9af198349069cdc7afeba). You can view the integer values the error macros in [this file](https://github.com/ARMmbed/mbed-os/blob/master/features/netsocket/nsapi_types.h). A negative error code indicates failure, while 0 indicates success.
 
 #### The `connect()` method
 
-High-level API calls to an implementation of a network-socket API are **identical** across networking protocols. The only difference is the interface object constructor and the method through which you connect to the network. For example, a Wi-Fi connection requires an SSID and password, a cellular connection requires an APN and Ethernet doesn't require any credentials. Only the `connect` method syntax of the derived classes reflects these differences. The intended design allows the user to change out the connectivity of the app by adding a new library and changing the API call for connecting to the network.
+High-level API calls to an implementation of a network-socket API are **identical** across networking protocols. The only difference is the interface object constructor and the method through which you connect to the network. For example, a Wi-Fi connection requires an SSID and password, a cellular connection requires an APN and Ethernet doesn't require any credentials. Each interface type may provide overloaded `connect()` method with required parameters, but it is preferred to offer these parameters as a configuration values to allow network interfaces to be changed just by changing configuration file.
 
-Below is a demonstration with the code that sends an HTTP request over Ethernet:
+Below is a demonstration with the code that connects to a network and relies that required configuration are provided:
 
-```C++ TODO
-    EthernetInterface net;
-    int return_code = net.connect();
+```C++ NOCI
+    NetworkInterface *net = NetworkInterface::get_default_instance();
+    int return_code = net->connect();
     if (return_code < 0)
         printf("Error connecting to network %d\r\n", return_code);
-
-    // Open a socket on the network interface, and create a TCP connection to api.ipify.org
-    TCPSocket socket;
-    socket.open(&net);
-    socket.connect("api.ipify.org", 80);
-    char *buffer = new char[256];
-
-    // Send an HTTP request
-    strcpy(buffer, "GET / HTTP/1.1\r\nHost: api.ipify.org\r\n\r\n");
-    int scount = socket.send(buffer, strlen(buffer));
-
-    // Recieve an HTTP response and print out the response line
-    int rcount = socket.recv(buffer, 256);
-
-    // Close the socket to return its memory and bring down the network interface
-    socket.close();
-    delete[] buffer;
-
-    // Bring down the ethernet interface
-    net.disconnect();
 ```
 
-To change the connectivity to ESP8266 Wi-Fi, change these lines:
+To change the example to use other network interfaces or provide configuration values for WiFi or other types, see [Network interface: Default network interface](../apis/network-interfaces.html)
 
-```C++ TODO
-    EthernetInterface net;
-    int return_code = net.connect();
+#### Providing Socket API
+
+`NetworkStack` must implement following API in order to support TCP/UDP sockets:
+
+```C++ NOCI
+nsapi_error_t socket_open(nsapi_socket_t *handle, nsapi_protocol_t proto);
+nsapi_error_t socket_close(nsapi_socket_t handle);
+nsapi_error_t socket_bind(nsapi_socket_t handle, const SocketAddress &address);
+nsapi_error_t socket_listen(nsapi_socket_t handle, int backlog);
+nsapi_error_t socket_connect(nsapi_socket_t handle, const SocketAddress &address);
+nsapi_error_t socket_accept(nsapi_socket_t server, nsapi_socket_t *handle, SocketAddress *address = 0);
+nsapi_size_or_error_t socket_send(nsapi_socket_t handle, const void *data, nsapi_size_t size);
+nsapi_size_or_error_t socket_recv(nsapi_socket_t handle, void *data, nsapi_size_t size);
+nsapi_size_or_error_t socket_sendto(nsapi_socket_t handle, const SocketAddress &address, const void *data, nsapi_size_t size);
+nsapi_size_or_error_t socket_recvfrom(nsapi_socket_t handle, SocketAddress *address, void *buffer, nsapi_size_t size);
+nsapi_error_t setsockopt(nsapi_socket_t handle, int level, int optname, const void *optval, unsigned optlen);
+nsapi_error_t getsockopt(nsapi_socket_t handle, int level, int optname, void *optval, unsigned *optlen);
 ```
 
-To:
+Please note that as the blocking operation mode of Socket is provided by higher level Socket API, the underlying calls to `NetworkStack` object should not block. This forces some network operations to be done in separate worker thread or in shared event queue. Any calls to these functions should return `NSAPI_ERROR_WOULD_BLOCK` in case the operation cannot be immediately completed.
 
-```C++ TODO
-    ESP8266Interface net(TX_PIN, RX_PIN);
-    int return_code = net.connect("my_ssid", "my_password");
-```
+Refer to the Doxygen documentation of [NetworkStack](../mbed-os-api-doxy/class_network_stack.html) for API descriptions.
 
 ### Testing
 
-When adding a new connectivity class, you can use `mbed test` to verify your implementation.
+To test new `NetworkStack` implementations full set of Mbed OS socket tests should be run.
 
-1. Make a new Mbed OS project: `mbed new [directory_name]`, where directory name is the name you'd like to use as your testing directory.
-1. Move into that folder: `cd [directory_name]`.
-1. Add your library to the project: `mbed add [driver URL]` or copy the driver files to this directory.
-1. You need to create a JSON test configuration file using the following format:
+Follow the guide from [Network Socket test plan](https://github.com/ARMmbed/mbed-os/blob/master/TESTS/netsocket/README.md).
 
-    ```JSON
-    {
-        "config": {
-            "header-file": {
-                "help" : "String for including your driver header file",
-                "value" : "\"EthernetInterface.h\""
-            },
-            "object-construction" : {
-                "value" : "new EthernetInterface()"
-            },
-            "connect-statement" : {
-                "help" : "Must use 'net' variable name",
-                "value" : "((EthernetInterface *)net)->connect()"
-            },
-            "echo-server-addr" : {
-                "help" : "IP address of echo server",
-                "value" : "\"195.34.89.241\""
-            },
-            "echo-server-port" : {
-                "help" : "Port of echo server",
-                "value" : "7"
-            },
-            "tcp-echo-prefix" : {
-                "help" : "Some servers send a prefix before echoed message",
-                "value" : "\"u-blox AG TCP/UDP test service\\n\""
-            }
-        }
-    }
-    ```
+Building and running the tests require you to provide the `mbed_app.json` as guided, and run the test with `mbed test -n mbed-os-tests-network-*,mbed-os-tests-netsocket*`
 
-    The configuration values you need to replace are `header-file`, `object-construction` and `connect-statement`.
-
-    - `header-file` - Replace `EthernetInterface.h` with the correct header file of your class
-    - `object-construction` - Replace `EthernetInterface()` with the syntax for your class' object construction.
-    - `connect-statement` - Replace `EthernetInterface*` with a pointer type to your class and `connect()` to match your class' connect function signature.
-
-1. Save the content as a new JSON file.
-1. Run the following command to execute the tests:
-    `mbed test -m [MCU] -t [toolchain] -n mbed-os-tests-netsocket* --test-config path/to/config.json`
-1. Use `-vv` for very verbose to view detailed test output.
 
 ### Case Study: ESP8266 Wi-Fi component
 
@@ -176,7 +133,7 @@ To send AT commands 1-2, there is an `ESP8266` method called [`startup(int mode)
 
 The necessary code is:
 
-```C++ TODO
+```C++ NOCI
 
 bool ESP8266::startup(int mode)
 {
@@ -198,7 +155,7 @@ The parser's `send` function returns true if the command succesully sent to the 
 
 So far, our connect method looks something like:
 
-```C++ TODO
+```C++ NOCI
 int ESP8266Interface::connect()
 {
     if (!_esp.startup(3)) {
@@ -214,13 +171,13 @@ Of them, the most appropriate is `NSAPI_ERROR_DEVICE_ERROR`. So replace `X` in t
 
 ##### Finishing
 
-You implemented similar methods to `startup` in ESP8266 to send AT commands 3-5. Then, you used them to determine the success of the `connect()` method. You can find the completed implementation [here](https://github.com/ARMmbed/esp8266-driver/blob/master/ESP8266Interface.cpp#L47-L68).  
+You implemented similar methods to `startup` in ESP8266 to send AT commands 3-5. Then, you used them to determine the success of the `connect()` method. You can find the completed implementation [here](https://github.com/ARMmbed/esp8266-driver/blob/master/ESP8266Interface.cpp#L47-L68).
 
 #### Implementing `socket_open`
 
 The `NetworkStack` parent class dictates that you implement the functionality of opening a socket. This is the method signature in the interface:
 
-```C++ TODO
+```C++ NOCI
 int ESP8266Interface::socket_open(void **handle, nsapi_protocol_t proto)
 ```
 
@@ -230,7 +187,7 @@ The ESP8266 module can only handle 5 open sockets, so you want to ensure that yo
 
 So far, the method looks like this:
 
-```C++ TODO
+```C++ NOCI
 int ESP8266Interface::socket_open(void **handle, nsapi_protocol_t proto)
 {
     // Look for an unused socket
@@ -253,7 +210,7 @@ int ESP8266Interface::socket_open(void **handle, nsapi_protocol_t proto)
 
 After you've determined that you have an open socket, you want to store some information in the `handle` parameter. We've created a `struct` to store information about the socket that will be necessary for network operations:
 
-```C++ TODO
+```C++ NOCI
 struct esp8266_socket {
     int id; // Socket ID number
     nsapi_protocol_t proto; // TCP or UDP
@@ -264,7 +221,7 @@ struct esp8266_socket {
 
 Create one of these, store some information in it and then point the `handle` at it:
 
-```C++ TODO
+```C++ NOCI
 int ESP8266Interface::socket_open(void **handle, nsapi_protocol_t proto)
 {
     ...
@@ -287,7 +244,7 @@ See the full implementation [here](https://github.com/ARMmbed/esp8266-driver/blo
 
 The `NetworkStack` parent class dictates that you implement the functionality of connecting a socket to a remote server. This is the method signature in the interface:
 
-```C++ TODO
+```C++ NOCI
 int ESP8266Interface::socket_connect(void *handle, const SocketAddress &addr)
 ```
 
@@ -295,7 +252,7 @@ In this case, the handle is one that has been assigned in the [`socket_open`](ht
 
 You can cast the void pointer to an `esp8266_socket` pointer. Do this in the body of `socket_connect`:
 
-```C++ TODO
+```C++ NOCI
 int ESP8266Interface::socket_connect(void *handle, const SocketAddress &addr)
 {
     struct esp8266_socket *socket = (struct esp8266_socket *)handle;
@@ -318,7 +275,7 @@ Access the socket ID and socket protocol from the members of `esp8266_socket`. A
 
 This method sends the AT command for opening a socket to the Wi-Fi module and is defined as follows:
 
-```C++ TODO
+```C++ NOCI
 bool ESP8266::open(const char *type, int id, const char* addr, int port)
 {
     //IDs only 0-4
@@ -337,7 +294,7 @@ In this instance, use the AT command parser to send `AT+CIPSTART=[id],[TCP or UD
 
 The `NetworkStack` parent class dictates that you implement the functionality of registering a callback on state change of the socket. This is the method signature in the interface:
 
-```C++ TODO
+```C++ NOCI
 void ESP8266Interface::socket_attach(void *handle, void (*callback)(void *), void *data)
 ```
 
@@ -345,7 +302,7 @@ Call the specified callback on state changes, such as when the socket can recv/s
 
 ESP8266 can have up to five open sockets. You need to keep track of all their callbacks. This [struct](https://github.com/ARMmbed/esp8266-driver/blob/master/ESP8266Interface.h#L269-L272) holds the callback as well as the data of these callbacks. It is stored as a private class variable `_cbs`:
 
-```C++ TODO
+```C++ NOCI
 struct {
     void (*callback)(void *);
     void *data;
@@ -354,10 +311,10 @@ struct {
 
 The attach method is:
 
-```C++ TODO
+```C++ NOCI
 void ESP8266Interface::socket_attach(void *handle, void (*callback)(void *), void *data)
 {
-    struct esp8266_socket *socket = (struct esp8266_socket *)handle;    
+    struct esp8266_socket *socket = (struct esp8266_socket *)handle;
     _cbs[socket->id].callback = callback;
     _cbs[socket->id].data = data;
 }
@@ -365,7 +322,7 @@ void ESP8266Interface::socket_attach(void *handle, void (*callback)(void *), voi
 
 Store the information in the `_cbs` struct for use on state changes. There is a method `event()` to call socket callbacks. It looks like this:
 
-```C++ TODO
+```C++ NOCI
 void ESP8266Interface::event() {
     for (int i = 0; i < ESP8266_SOCKET_COUNT; i++) {
         if (_cbs[i].callback) {
@@ -389,28 +346,22 @@ Know when to trigger these events. You've used the `ESP8266` class object, `_esp
 ```
 {
     "config": {
-        "header-file": {
-            "help" : "String for including your driver header file",
-            "value" : "\"ESP8266Interface.h\""
-        },
-        "object-construction" : {
-            "value" : "new ESP8266Interface(D1, D0)"
-        },
-        "connect-statement" : {
-            "help" : "Must use 'net' variable name",
-            "value" : "((ESP8266Interface *)net)->connect(\"my_ssid\", \"my_password\")"
-        },
         "echo-server-addr" : {
             "help" : "IP address of echo server",
-            "value" : "\"195.34.89.241\""
+            "value" : "\"echo.mbedcloudtesting.com\""
         },
         "echo-server-port" : {
             "help" : "Port of echo server",
             "value" : "7"
-        },
-        "tcp-echo-prefix" : {
-            "help" : "Some servers send a prefix before echoed message",
-            "value" : "\"u-blox AG TCP/UDP test service\\n\""
+        }
+    },
+    "target_overrides": {
+        "*": {
+            "target.network-default-interface-type": "WIFI",
+            "nsapi.default-wifi-ssid": "\"WIFI_SSID\"",
+            "nsapi.default-wifi-password": "\"WIFI_PASSWORD\"",
+            "nsapi.default-wifi-security": "WIFI_SECURITY",
+            "esp8266.provide-default": true
         }
     }
 }
@@ -421,46 +372,78 @@ Know when to trigger these events. You've used the `ESP8266` class object, `_esp
 
 ```shell
 mbedgt: test suite report:
-+--------------+---------------+--------------------------------------------+--------+--------------------+-------------+
-| target       | platform_name | test suite                                 | result | elapsed_time (sec) | copy_method |
-+--------------+---------------+--------------------------------------------+--------+--------------------+-------------+
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-connectivity       | OK     | 32.24              | shell       |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-gethostbyname      | OK     | 24.01              | shell       |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-ip_parsing         | OK     | 14.31              | shell       |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-socket_sigio       | OK     | 29.23              | shell       |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp_echo           | OK     | 51.39              | shell       |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp_hello_world    | OK     | 21.03              | shell       |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-udp_dtls_handshake | OK     | 19.65              | shell       |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-udp_echo           | OK     | 23.22              | shell       |
-+--------------+---------------+--------------------------------------------+--------+--------------------+-------------+
-mbedgt: test suite results: 8 OK
++--------------+---------------+---------------------------------+---------+--------------------+-------------+
+| target       | platform_name | test suite                      | result  | elapsed_time (sec) | copy_method |
++--------------+---------------+---------------------------------+---------+--------------------+-------------+
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-dns     | TIMEOUT | 148.28             | default     |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp     | TIMEOUT | 1035.26            | default     |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-udp     | FAIL    | 383.8              | default     |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-interface | TIMEOUT | 508.17             | default     |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-wifi      | OK      | 131.04             | default     |
++--------------+---------------+---------------------------------+---------+--------------------+-------------+
+mbedgt: test suite results: 1 FAIL / 1 OK / 3 TIMEOUT
 mbedgt: test case report:
-+--------------+---------------+--------------------------------------------+----------------------------------------+--------+--------+--------+--------------------+
-| target       | platform_name | test suite                                 | test case                              | passed | failed | result | elapsed_time (sec) |
-+--------------+---------------+--------------------------------------------+----------------------------------------+--------+--------+--------+--------------------+
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-connectivity       | Bringing the network up and down       | 1      | 0      | OK     | 7.61               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-connectivity       | Bringing the network up and down twice | 1      | 0      | OK     | 10.74              |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-gethostbyname      | DNS literal                            | 1      | 0      | OK     | 0.09               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-gethostbyname      | DNS preference literal                 | 1      | 0      | OK     | 0.1                |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-gethostbyname      | DNS preference query                   | 1      | 0      | OK     | 0.13               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-gethostbyname      | DNS query                              | 1      | 0      | OK     | 0.15               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-ip_parsing         | Hollowed IPv6 address                  | 1      | 0      | OK     | 0.06               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-ip_parsing         | Left-weighted IPv4 address             | 1      | 0      | OK     | 0.07               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-ip_parsing         | Left-weighted IPv6 address             | 1      | 0      | OK     | 0.06               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-ip_parsing         | Null IPv4 address                      | 1      | 0      | OK     | 0.04               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-ip_parsing         | Null IPv6 address                      | 1      | 0      | OK     | 0.05               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-ip_parsing         | Right-weighted IPv4 address            | 1      | 0      | OK     | 0.06               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-ip_parsing         | Right-weighted IPv6 address            | 1      | 0      | OK     | 0.06               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-ip_parsing         | Simple IPv4 address                    | 1      | 0      | OK     | 0.05               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-ip_parsing         | Simple IPv6 address                    | 1      | 0      | OK     | 0.04               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-socket_sigio       | Socket Attach Test                     | 1      | 0      | OK     | 2.04               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-socket_sigio       | Socket Detach Test                     | 1      | 0      | OK     | 6.26               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-socket_sigio       | Socket Reattach Test                   | 1      | 0      | OK     | 1.36               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp_echo           | TCP echo                               | 1      | 0      | OK     | 6.24               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp_hello_world    | TCP hello world                        | 1      | 0      | OK     | 7.34               |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-udp_dtls_handshake | UDP DTLS handshake                     | 1      | 0      | OK     | 5.9                |
-| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-udp_echo           | UDP echo                               | 1      | 0      | OK     | 9.75               |
-+--------------+---------------+--------------------------------------------+----------------------------------------+--------+--------+--------+--------------------+
-mbedgt: test case results: 22 OK
-mbedgt: completed in 217.24 sec
++--------------+---------------+---------------------------------+---------------------------------------+--------+--------+---------+--------------------+
+| target       | platform_name | test suite                      | test case                             | passed | failed | result  | elapsed_time (sec) |
++--------------+---------------+---------------------------------+---------------------------------------+--------+--------+---------+--------------------+
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-dns     | ASYNCHRONOUS_DNS                      | 0      | 0      | ERROR   | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-dns     | ASYNCHRONOUS_DNS_CACHE                | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-dns     | ASYNCHRONOUS_DNS_CANCEL               | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-dns     | ASYNCHRONOUS_DNS_EXTERNAL_EVENT_QUEUE | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-dns     | ASYNCHRONOUS_DNS_INVALID_HOST         | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-dns     | ASYNCHRONOUS_DNS_NON_ASYNC_AND_ASYNC  | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-dns     | ASYNCHRONOUS_DNS_SIMULTANEOUS         | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-dns     | ASYNCHRONOUS_DNS_SIMULTANEOUS_CACHE   | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-dns     | ASYNCHRONOUS_DNS_SIMULTANEOUS_REPEAT  | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-dns     | ASYNCHRONOUS_DNS_TIMEOUTS             | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-dns     | SYNCHRONOUS_DNS                       | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-dns     | SYNCHRONOUS_DNS_INVALID               | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-dns     | SYNCHRONOUS_DNS_MULTIPLE              | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp     | TCPSOCKET_CONNECT_INVALID             | 1      | 0      | OK      | 0.11               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp     | TCPSOCKET_ECHOTEST                    | 1      | 0      | OK      | 2.93               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp     | TCPSOCKET_ECHOTEST_BURST              | 1      | 0      | OK      | 29.44              |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp     | TCPSOCKET_ECHOTEST_BURST_NONBLOCK     | 1      | 0      | OK      | 28.92              |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp     | TCPSOCKET_ECHOTEST_NONBLOCK           | 1      | 0      | OK      | 4.91               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp     | TCPSOCKET_ENDPOINT_CLOSE              | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp     | TCPSOCKET_OPEN_CLOSE_REPEAT           | 1      | 0      | OK      | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp     | TCPSOCKET_OPEN_LIMIT                  | 1      | 0      | OK      | 0.22               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp     | TCPSOCKET_RECV_100K                   | 0      | 0      | ERROR   | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp     | TCPSOCKET_RECV_100K_NONBLOCK          | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp     | TCPSOCKET_RECV_TIMEOUT                | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp     | TCPSOCKET_SEND_REPEAT                 | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp     | TCPSOCKET_SEND_TIMEOUT                | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-tcp     | TCPSOCKET_THREAD_PER_SOCKET_SAFETY    | 1      | 0      | OK      | 2.72               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-udp     | UDPSOCKET_ECHOTEST                    | 1      | 0      | OK      | 3.07               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-udp     | UDPSOCKET_ECHOTEST_BURST              | 1      | 0      | OK      | 54.99              |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-udp     | UDPSOCKET_ECHOTEST_BURST_NONBLOCK     | 1      | 0      | OK      | 55.94              |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-udp     | UDPSOCKET_ECHOTEST_NONBLOCK           | 1      | 0      | OK      | 10.03              |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-udp     | UDPSOCKET_OPEN_CLOSE_REPEAT           | 1      | 0      | OK      | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-udp     | UDPSOCKET_OPEN_LIMIT                  | 1      | 0      | OK      | 0.22               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-udp     | UDPSOCKET_SENDTO_INVALID              | 1      | 0      | OK      | 19.14              |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-udp     | UDPSOCKET_SENDTO_REPEAT               | 1      | 0      | OK      | 200.85             |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-netsocket-udp     | UDPSOCKET_SENDTO_TIMEOUT              | 0      | 2      | FAIL    | 4.25               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-interface | NETWORKINTERFACE_CONN_DISC_REPEAT     | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-interface | NETWORKINTERFACE_STATUS               | 0      | 0      | ERROR   | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-interface | NETWORKINTERFACE_STATUS_GET           | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-interface | NETWORKINTERFACE_STATUS_NONBLOCK      | 0      | 0      | SKIPPED | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-wifi      | WIFI-CONNECT                          | 1      | 0      | OK      | 6.56               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-wifi      | WIFI-CONNECT-DISCONNECT-REPEAT        | 1      | 0      | OK      | 32.84              |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-wifi      | WIFI-CONNECT-NOCREDENTIALS            | 1      | 0      | OK      | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-wifi      | WIFI-CONNECT-PARAMS-CHANNEL           | 1      | 0      | OK      | 0.11               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-wifi      | WIFI-CONNECT-PARAMS-CHANNEL-FAIL      | 1      | 0      | OK      | 0.11               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-wifi      | WIFI-CONNECT-PARAMS-NULL              | 1      | 0      | OK      | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-wifi      | WIFI-CONNECT-PARAMS-VALID-SECURE      | 1      | 0      | OK      | 5.41               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-wifi      | WIFI-CONNECT-PARAMS-VALID-UNSECURE    | 1      | 0      | OK      | 6.65               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-wifi      | WIFI-CONNECT-SECURE                   | 1      | 0      | OK      | 5.25               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-wifi      | WIFI-CONNECT-SECURE-FAIL              | 1      | 0      | OK      | 15.32              |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-wifi      | WIFI-CONSTRUCTOR                      | 1      | 0      | OK      | 0.0                |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-wifi      | WIFI-GET-RSSI                         | 1      | 0      | OK      | 7.42               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-wifi      | WIFI-SCAN                             | 1      | 0      | OK      | 2.61               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-wifi      | WIFI-SCAN-NULL                        | 1      | 0      | OK      | 17.6               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-wifi      | WIFI-SET-CHANNEL                      | 1      | 0      | OK      | 0.11               |
+| K64F-GCC_ARM | K64F          | mbed-os-tests-network-wifi      | WIFI-SET-CREDENTIAL                   | 1      | 0      | OK      | 0.0                |
++--------------+---------------+---------------------------------+---------------------------------------+--------+--------+---------+--------------------+
+mbedgt: test case results: 1 FAIL / 20 SKIPPED / 32 OK / 3 ERROR
+mbedgt: completed in 2207.72 sec
+mbedgt: exited with code 4
 ```

--- a/docs/porting/connectivity/NetworkStack.md
+++ b/docs/porting/connectivity/NetworkStack.md
@@ -36,6 +36,8 @@ Each subclass has distinct pure virtual methods. Visit their class references (l
 
 Many functions of `NetworkStack` and `NetworkInterface` have return types of `nsapi_error_t`, which is a type used to represent error codes. You can see a [list of these return codes](http://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__netsocket.html#gac21eb8156cf9af198349069cdc7afeba). You can view the [integer values of the error macros](https://github.com/ARMmbed/mbed-os/blob/master/features/netsocket/nsapi_types.h). A negative error code indicates failure, and 0 indicates success.
 
+Functions that send or receive data, use `nsapi_size_or_error_t` type as a return value, where positive values indicate how much data has been sent or received, negative return values are error codes and zero is indication of closed connection.
+
 #### The `connect()` method
 
 High-level API calls to an implementation of a network-socket API are **identical** across networking protocols. The only difference is the interface object constructor and the method through which you connect to the network. For example, a Wi-Fi connection requires an SSID and password, a cellular connection requires an APN and Ethernet doesn't require any credentials. Each interface type may provide an overloaded `connect()` method with required parameters, but the preferred method is to offer these parameters as configuration values to allow the changing of network interfaces by changing a configuration file.


### PR DESCRIPTION
Socket porting part was missing information about non-blocking
behaviour of the underlying stack calls.

Connect call was not mentioning the default interfaces at all.

Testing section was having outdated information. Replaced with the
link to current test plan.

Modify the ESP case study with up to date JSON and test result.