### PR TITLE
Update updating_firmware.md

### DIFF
--- a/docs/tools/IDE/updating_firmware.md
+++ b/docs/tools/IDE/updating_firmware.md
@@ -2,7 +2,7 @@
 
 The Online Compiler integrates with Pelion Device Management's remote firmware update services.
 
-<span class="tips">**Tip**: The fastest way to learn about firmware updates in the Online Compiler is to try the [connecting quick start](https://cloud.mbed.com/guides/connect-device-to-pelion) to create the original application, and the [update quick start](https://cloud.mbed.com/guides/pelion-firmware-update) to perform a firmware update.</span>
+<span class="tips">**Tip**: The fastest way to learn about firmware updates in the Online Compiler is to try the [Quick Connect guide](https://cloud.mbed.com/guides/connect-device-to-pelion) to create the original application, and the [Quick Update guide](https://cloud.mbed.com/guides/pelion-firmware-update) to perform a firmware update.</span>
 
 <span class="notes">You need a [Pelion Device Management](https://portal.mbedcloud.com/login) account to use the update workflow.</span>
 
@@ -10,17 +10,17 @@ The Online Compiler integrates with Pelion Device Management's remote firmware u
 
 To be able to receive updates, an application must have:
 
-* A **connect certificate** to access a Device Management account. When you run the application on your device, the bootstrap server will use this developer connect certificate to authenticate your application with your Pelion Device Management account.
-* An **update certificate** to verify incoming updates.
+* A **connect certificate** to access a Pelion Device Management account. When you run the application on your device, the bootstrap server will use this connect certificate to authenticate your application with your Pelion Device Management account.
+* An **update certificate** to verify that incoming updates come from a trusted source.
 * A **bootloader** to verify and install update images.
-* The Device Management Client, [normally imported as part of the example application](https://github.com/ARMmbed/mbed-cloud-client-example). You can also do this with the [quick start we mentioned above](https://cloud.mbed.com/guides/connect-device-to-pelion).
+* The Device Management Client, [normally imported as part of the example application](https://github.com/ARMmbed/mbed-cloud-client-example). You can also do this with the [Quick Connect guide we mentioned above](https://cloud.mbed.com/guides/connect-device-to-pelion).
 
 And you need:
 
 * A **private key** so you can sign the firmware update manifest file.
 * A **manifest file**, which defines the update, including the location of the new firmware image and the type of device the update applies to. The manifest file is signed with the private key to assure the device that the image is from a trusted source and has not been tampered with.
 
-For development use cases only, you can use the Online Compiler to generate these and combine them into a single image. For production use cases, you would use offline tools to generate these certificates and store them securely. Learn more [about the developer workflow below](#notes-about-the-developer-workflow).
+For development use cases only, you can use the Online Compiler to generate the certificates and the manifest file. For production use cases, you would use offline tools to generate and store them securely. Learn more [about the developer workflow below](#notes-about-the-developer-workflow).
 
 ### Creating an update image
 
@@ -32,14 +32,14 @@ In the **Pelion Device Management** dropdown menu, you can:
 
 * Create the initial application:
 
-    * **Pelion Connect Certificates**: create a developer certificate, and see existing ones. Note: this process uses your Device Management API key. If the key is not found, you will be prompted to enter it manually. You can create an API key in the [Pelion Device Management portal](https://portal.mbedcloud.com/access/keys).
+    * **Manage Connect Certificates**: create a developer connect certificate, and see existing ones. Note: this process uses your Device Management API key. If the key is not found, you will be prompted to enter it manually. You can create an API key in the [Pelion Device Management portal](https://portal.mbedcloud.com/access/keys).
     * **Apply Update Certificate**: create an update certificate and generate a private key for manifest signing. Note: you need to download the private key and store it securely.
 
     When you build your application, the Online Compiler will combine the bootloader with your certificates and your application code.
 
 * Create an update image:
 
-    * **Publish Firmware Update**: build your program so you can use it as a firmware update. This build does not include the certificates or the bootloader.
+    * **Publish Firmware Update**: build your program and upload it to your Pelion Device Management account so you can use it as a firmware update. This build does not include the certificates or the bootloader.
 
     This stage also creates a manifest for the update, and will ask for your private key to sign the manifest.
 
@@ -48,5 +48,5 @@ In the **Pelion Device Management** dropdown menu, you can:
 The Device Management workflow in the Online Compiler is intended only for development devices; it does not support deployment requirements:
 
 * The Online Compiler uses web crypto to generate the update public certificate and private key and is not available in Internet Explorer or Microsoft Edge.
-* The update certificate and key are not suitable for production use cases.
+* The developer update certificate and key are not suitable for production use cases.
 * The developer connect certificate file contains multiple certificates and a private key. It is not suitable for production and you must keep it safe so as not to expose the private key.


### PR DESCRIPTION
- L13: this section is not limited to developer workflow - connect certificate could be development or production. 
- L16: "You can also do this with..." confused me - do what? Importing the client is not called out explicitly in the Quick Connect guide - we do it as part of importing the example application. 
- L23: Certificates and manifest should all be created offline for production use cases. The manifest is not included in the image - it's a separate artefact. 
L48: "Deployment" vs "production"?