### PR TITLE
Add 'sudo' to 'pip install mbed-cli'

### DIFF
--- a/docs/tutorials/quickstart/quick-start-cli.md
+++ b/docs/tutorials/quickstart/quick-start-cli.md
@@ -34,7 +34,7 @@ Download and install a compiler.
 
 ###### 3. Install Mbed CLI
 
-To install Mbed CLI, run `pip install mbed-cli` from your command-line.
+To install Mbed CLI, run `sudo pip install mbed-cli` from your command-line.
 
 You can ensure Mbed CLI installed correctly by running `mbed --version`.
 

--- a/docs/tutorials/quickstart/quick-start-cli.md
+++ b/docs/tutorials/quickstart/quick-start-cli.md
@@ -34,7 +34,7 @@ Download and install a compiler.
 
 ###### 3. Install Mbed CLI
 
-To install Mbed CLI, run `sudo pip install mbed-cli` from your command-line.
+To install Mbed CLI, run `pip install mbed-cli` from your command-line.
 
 You can ensure Mbed CLI installed correctly by running `mbed --version`.
 
@@ -70,7 +70,7 @@ Download and install a compiler.
 
 ##### 3. Install Mbed CLI
 
-To install Mbed CLI, run `pip install mbed-cli` from your command-line.
+To install Mbed CLI, run `sudo pip install mbed-cli` from your command-line.
 
 You can ensure Mbed CLI installed correctly by running `mbed --version`.
 
@@ -110,7 +110,7 @@ Download and install a compiler:
 
 ##### 3. Install Mbed CLI
 
-To install Mbed CLI, run `pip install mbed-cli` from your command-line.
+To install Mbed CLI, `sudo pip install mbed-cli` from your command-line.
 
 You can ensure Mbed CLI installed correctly by running `mbed help`.
 


### PR DESCRIPTION
Sudo is required in order to install mbed-cli. Adding this to the documentation.