### PR TITLE
Add PSA-SPM porting guide

### DIFF
--- a/docs/porting/psa/spm.md
+++ b/docs/porting/psa/spm.md
@@ -63,13 +63,13 @@ Typically, PSA platforms share the same RAM and flash between secure and nonsecu
 ```text
                                  RAM
  +-----------+-------------+--------------------------------------------------+
- |   Secure  |  Shared     |     Non-Secure                                   |
+ |   Secure  |  Shared     |     Nonsecure                                   |
  |    RAM    |   RAM       |        RAM                                       |
  +-----------+-------------+--------------------------------------------------+
 
                                  Flash
  +-----------------------+----------------------------------------------------+
- |   Secure              |     Non-Secure                                     |
+ |   Secure              |     Nonsecure                                     |
  |    Flash              |       Flash                                        |
  +-----------------------+----------------------------------------------------+
 
@@ -85,7 +85,7 @@ Linker scripts must include `MBED_ROM_START`, `MBED_ROM_SIZE`, `MBED_RAM_START` 
 
 Typically, shared memory is located adjacent (before or after) to the nonsecure RAM, for saving MPU regions. The shared memory region is nonsecure memory that both cores use.
 
-#### Linker script example for GCC_ARM
+#### Linker script example for GCC_ARM compiler
 
 ```
 ...
@@ -116,7 +116,7 @@ MEMORY
 ...
 ```
 
-#### Linker script example for ARM
+#### Linker script example for ARM compiler
 
 ```
 ...
@@ -157,7 +157,7 @@ LR_IROM1 MBED_ROM_START MBED_ROM_SIZE {
 ...
 ```
 
-#### Linker script example for IAR
+#### Linker script example for IAR compiler
 
 ```
 ...
@@ -256,6 +256,6 @@ Arm provides a list of tests to make sure the HAL functions are implemented acco
 After finalizing the porting, execute the following tests:
 
 - **tests-psa-spm_smoke:** This test will make sure that the porting of the mailbox mechanism (for dual core systems) is successful.
-- **tests-mbed_hal-spm:** This test will make sure the porting of the memory protection (*spm_hal_memory_protection_init()* implementation) makes the correct partitioning between secure RAM/Flash and non-secure RAM/Flash.
+- **tests-mbed_hal-spm:** This test will make sure the porting of the memory protection (*spm_hal_memory_protection_init()* implementation) makes the correct partitioning between secure RAM/Flash and nonsecure RAM/Flash.
 
 We recommended you leave the memory protection part (*spm_hal_memory_protection_init()* implementation) to the end of the porting. First, implement and test other HAL functions. After these tests pass, implement *spm_hal_memory_protection_init()*, and run the entire test suite again, including the memory protection related tests.

--- a/docs/porting/psa/spm.md
+++ b/docs/porting/psa/spm.md
@@ -14,13 +14,13 @@ Typically, PSA platforms share the same RAM and flash between secure and nonsecu
                                  RAM
  +-----------+-------------+--------------------------------------------------+
  |   Secure  |  Shared     |     Non-Secure                                   |
- |      RAM  |     RAM     |            RAM                                   |
+ |    RAM    |   RAM       |        RAM                                       |
  +-----------+-------------+--------------------------------------------------+
 
                                  Flash
  +-----------------------+----------------------------------------------------+
  |   Secure              |     Non-Secure                                     |
- |      Flash            |            Flash                                   |
+ |    Flash              |       Flash                                        |
  +-----------------------+----------------------------------------------------+
 
 ```
@@ -79,11 +79,12 @@ To achieve RAM and flash partitioning, you must add start and size values to a t
 
 Linker scripts must include `MBED_ROM_START`, `MBED_ROM_SIZE`, `MBED_RAM_START` and `MBED_RAM_START` macros for defining memory regions. You can define a shared memory region by reserving RAM space for shared memory use. The shared memory location is target specific and depends on the memory protection scheme applied.
 
-Typically, shared memory is located before or after nonsecure RAM, for saving MPU regions. The shared memory region is nonsecure memory that both cores use.
+Typically, shared memory is located adjacent (before or after) to the nonsecure RAM, for saving MPU regions. The shared memory region is nonsecure memory that both cores use.
 
-#### Linker script example GCC_ARM
+#### Linker script example for GCC_ARM
 
 ```
+...
 #if !defined(MBED_ROM_START)
   #define MBED_ROM_START    0x10000000
 #endif
@@ -111,9 +112,10 @@ MEMORY
 ...
 ```
 
-#### Linker Script example ARM
+#### Linker script example for ARM
 
 ```
+...
 #if !defined(MBED_ROM_START)
   #define MBED_ROM_START    0x10000000
 #endif
@@ -148,11 +150,13 @@ LR_IROM1 MBED_ROM_START MBED_ROM_SIZE {
    .ANY (+RW +ZI)
   }
 }
+...
 ```
 
-#### Linker script example IAR
+#### Linker script example for IAR
 
 ```
+...
 if (!isdefinedsymbol(MBED_ROM_START)) {
   define symbol MBED_ROM_START = 0x10000000;
 }
@@ -247,8 +251,7 @@ Arm provides a list of tests to make sure the HAL functions are implemented acco
 
 After finalizing the porting, execute the following tests:
 
-- [TODO: WHEN READY, ADD TEST NAME]
-- [TODO: WHEN READY, ADD TEST NAME]
-- ...
+- **tests-psa-spm_smoke:** This test will make sure that the porting of the mailbox mechanism (for dual core systems) is successful.
+- **tests-mbed_hal-spm:** This test will make sure the porting of the memory protection (*spm_hal_memory_protection_init()* implementation) makes the correct partitioning between secure RAM/Flash and non-secure RAM/Flash.
 
 We recommended you leave the memory protection part (*spm_hal_memory_protection_init()* implementation) to the end of the porting. First, implement and test other HAL functions. After these tests pass, implement *spm_hal_memory_protection_init()*, and run the entire test suite again, including the memory protection related tests.

--- a/docs/porting/psa/spm.md
+++ b/docs/porting/psa/spm.md
@@ -1,0 +1,167 @@
+<h2 id="blockdevice-port">PSA SPM</h2>
+
+SPM (Secure Partition Manager) is a part of the PSA Firmware Framework that is responsible for isolating software in Partitions, managing the execution of software within Partitions, and providing IPC between Partitions.
+
+For more information about SPM, refer to [TODO: WHEN READY, SPM OVERVIEW PAGE LINK]
+
+**This page gives guidelines for silicon partners wishing to have Secure Partition Manager capabilities**
+
+
+## Linker Scripts
+
+Silicon partners must edit the secure and non-secure linker scripts to define sections for RAM, FLASH and SHARED_RAM.
+
+Linker scripts guidelines:
+- *__shared_memory_start* symbol is used in SPM code so it must be set with the start address of the shared memory
+- *__shared_memory_start* must be 4 bytes aligned
+- *__shared_memory_end* symbol is used in SPM code so it must be set with the end address of the shared memory
+- SHARED_RAM must have Read/Write permissions from secure and non-secure cores
+- SHARED_RAM address must be 4 bytes aligned
+- SHARED_RAM must be given a minimum memory space of 256 bytes
+- Secure RAM base address must be 4 bytes aligned and have Read/Write permissions only from secure core
+- Secure FLASH base address must be 4 bytes aligned and have Read/Write/Execute permissions only from secure core
+- Non-Secure RAM base address must be 4 bytes aligned and have Read/Write permissions from secure and non-secure cores
+- Non-Secure FLASH base address must be 4 bytes aligned; must have Read permissions from secure and non-secure cores, and Execute permissions from non-secure core; May have Write permissions from secure and non-secure cores
+
+This is an example of the relevant parts inside the linker scripts:
+
+#### SECURE Core Linker Script
+
+```
+...
+...
+MEMORY
+{
+    /* The ram and flash regions control RAM and flash memory allocation for the SECURE core.
+     * You can change the memory allocation by editing the 'ram' and 'flash' regions.
+     * Your changes must be aligned with the corresponding memory regions for the NON-SECURE core in the 
+     * NON-SECURE linker script.
+     */
+    ram               (rwx)   : ORIGIN = 0x08000000, LENGTH = 0x10000
+    shared_ram        (rw)    : ORIGIN = 0x08010000, LENGTH = 0x1000
+    flash             (rx)    : ORIGIN = 0x10000000, LENGTH = 0x78000
+    
+    ...
+    ...
+}
+
+...
+...
+
+/* .shared_mem section contains memory shared between SECURE core and NON-SECURE core */
+.shared_mem :
+{
+    __shared_memory_start = .;
+    . += 0x1000;
+    __shared_memory_end = .;
+
+    /* Check if section is 4 bytes aligned */
+    ASSERT (((__shared_memory_start % 4) == 0), "Error: shared_mem section is not 4 bytes aligned!!");
+} > shared_ram
+
+...
+...
+```
+
+#### NON-SECURE Core Linker Script
+```
+...
+...
+MEMORY
+{
+    /* The ram and flash regions control RAM and flash memory allocation for the NON-SECURE core.
+     * You can change the memory allocation by editing the 'ram' and 'flash' regions.
+     * Your changes must be aligned with the corresponding memory regions for the SECURE core in the 
+     * SECURE linker script.
+     */
+    ram               (rwx)   : ORIGIN = 0x08011000, LENGTH = 0x36800
+    flash             (rx)    : ORIGIN = 0x10080000, LENGTH = 0x78000
+    
+    ...
+    ...
+}
+
+...
+...
+```
+
+
+## Mailbox
+
+Mailbox is the SPM mechanism in charge of Inter Processor Communication, and is **relevant for multi-core systems only**.
+
+#### Concepts
+The mailbox mechanism is based on message queues and dispatcher threads.
+Each core has a single dispatcher thread, and a single message queue.
+The dispatcher thread waits on a mailbox event. Once this event occurs, the dispatcher thread reads and runs "tasks" accumulated on its local message queue. 
+
+#### Requirements
+The SPM mailbox mechanism requires that the platform should have the following capabilities:
+* Inter Processor Communication capabilities - The ability to notify the peer processor about an event (usually implemented with interrupts)
+* Ability to set a RAM section which is shared between the cores
+
+#### Porting
+These are the guidelines which should be followed by silicon partners with multi-core systems:
+- For each core, initialize, configure and enable the a mailbox event (usually an interrupt) at SystemInit()
+- For each core, implement the mailbox event handler (usually interrupt handler):
+  - This handler must call an ARM callback function. This is explained in more details in the [HAL Functions section](#hal-functions)
+  - It is the silicon partner's responsibility to clear the mailbox event. This can be done in the event handler.
+- For each core, implement the HAL function which notifies the peer processor about a mailbox event occurrence. This is a part of the HAL, and explained in more details in the [HAL Functions section](#hal-functions)
+
+
+## HAL Functions
+
+Target specific code of silicon partners who wish to have SPM capabilities must:
+- Implement a list of functions which are being called by SPM code
+- Call other functions supplied by ARM
+
+The HAL can be logically divided into 3 different fields:
+
+#### Addresses
+This part of HAL allows the silicon partner to share the addresses set in the linker scripts with the SPM code. The SPM uses these addresses mostly to enforce access permissions.
+
+#### Mailbox
+This part of HAL allows the silicon partner to implement a thin layer of the mailbox mechanism which is specific to their platform.
+It must be implemented only by silicon partners with multi-core systems.
+
+#### Secure Processing Environment
+This part of HAL allows the silicon partner to apply their specific memory protection scheme.
+
+A list of these functions can be found here [TODO: WHEN READY, ADD LINK TO DOXYGEN FILES OF HAL FUNCTIONS]
+
+
+## Memory Protection
+
+As explained in the [HAL Functions section](#hal-functions), target specific code must implement the function *spm_hal_memory_protection_init()* called on SPM initialization.
+This function should apply memory protection schemes to ensure secure memory can only be accessed from secure-state.
+
+The implementation of this function, must be aligned with the SPM general guidelines as described in the table below.
+
+This table describes the allowed operations (Read / Write / Execute) on the Secure and Non-Secure RAM and FLASH by each core:
+
+- X means No Access
+- V means Must Be Able to Access
+- ? means it is up to the target
+- X? means it is up to the target, preferably No Access
+
+Processor Access    |Secure RAM        |Secure FLASH|Non Secure RAM     |Non Secure FLASH
+--------------------|------------------|------------|-------------------|----------------
+`Non Secure Read`   |   X              |    X       |        V          |    V
+`Non Secure Write`  |   X              |    X       |        V          |    ?
+`Non Secure Execute`|   X              |    X       |        X?         |    V
+`Secure Read`       |   V              |    V       |        V          |    V
+`Secure Write`      |   V              |    V       |        V          |    ?
+`Secure Execute`    |   X?             |    V       |        X          |    ?
+
+
+## Testing
+
+ARM provides a list of tests to make sure the HAL functions are implemented according to requirements, and the porting is done correctly.
+
+After finalizing the porting, the following tests should be executed:
+- [TODO: WHEN READY, ADD TEST NAME]
+- [TODO: WHEN READY, ADD TEST NAME]
+- ...
+
+It is recommended to leave the memory protection part [*spm_hal_memory_protection_init()* implementation] to the end of the porting.
+First implement and test other HAL functions, and after these tests pass, implement *spm_hal_memory_protection_init()* and run the entire test suite again, including the memory protection related tests.

--- a/docs/porting/psa/spm.md
+++ b/docs/porting/psa/spm.md
@@ -8,15 +8,14 @@ For more information about SPM, please refer to [the SPM overview page](/docs/de
 
 ### New target configuration
 
-When adding a new target, a new root target node should be added to mbed-os/targets/targets.json file.
-For PSA support, specific PSA related fields should be defined for this target:
+When adding a new target, a new root target node should be added to the `mbed-os/targets/targets.json` file. For PSA support, define specific PSA-related fields for this target:
 
-1. Secure target must inherit from `SPE_Target` meta-target.
+1. Secure target must inherit from `SPE_Target` metatarget.
 2. Nonsecure target must inherit from `NSPE_Target`.
 3. Only for multicore architectures:
-   - Both targets must add "SPM_MAILBOX" component. Mailbox mechanism is explained in [Mailbox section](#mailbox)
-   - Both targets must override the default configuration by specifying flash RAM and shared RAM regions. This is explained in more details in [Memory layout section](#memory-layout)
-   - Secure target must declare which is its corresponding nonsecure target using the "deliver_to_target" field.
+   - Both targets must add the `SPM_MAILBOX` component. You can read more about the mailbox mechanism in the [mailbox section](#mailbox).
+   - Both targets must override the default configuration by specifying flash RAM and shared RAM regions. The [memory layout section](#memory-layout) explains this in more detail.
+   - Secure target must declare its corresponding nonsecure target using the `deliver_to_target` field.
 
 These is demonstrated in the example below:
 
@@ -210,7 +209,7 @@ These are the guidelines you should follow if you have multicore systems:
 - For each core, implement the IPC event handler (usually interrupt handler):
   - The handler must call an Arm callback function. Refer to [HAL functions section](#hal-functions) for more details.
 - For each core, implement the HAL function that notifies the peer processor about a mailbox event occurrence. This is a part of the HAL, and the section below explains this in more detail.
-- For each core, add the "SPM_MAILBOX" component field for its target node in mbed-os/targets/targets.json file.
+- For each core, add the `SPM_MAILBOX` component field for its target node in the `mbed-os/targets/targets.json` file.
 
 ### HAL functions
 

--- a/docs/porting/psa/spm.md
+++ b/docs/porting/psa/spm.md
@@ -227,7 +227,7 @@ This part of HAL allows you to implement a thin layer of the mailbox mechanism t
 
 #### Secure Processing Environment
 
-This part of HAL allows you to apply your specific memory protection scheme. You can find a list of [these functions]([TODO: WHEN READY, ADD LINK TO DOXYGEN FILES OF HAL FUNCTIONS]).
+This part of HAL allows you to apply your specific memory protection scheme. You can find a list of [these functions](https://os.mbed.com/docs/development/mbed-os-api-doxy/group___s_p_m.html).
 
 ### Memory protection
 


### PR DESCRIPTION
The document is currently Work In Progress but its structure and most of its contents is here.
It is loaded as a PR so it can be reviewed by tech-writers.
Current gaps:
- Doxygen should be generated once SPM HAL is finalized, and then corresponding links will be added.
- HAL tests names will be updated once finalized.
- New sections might be added.