### PR TITLE
workflow: remove explicit CLA references

### DIFF
--- a/docs/reference/contributing/guidelines/design_guidelines.md
+++ b/docs/reference/contributing/guidelines/design_guidelines.md
@@ -49,7 +49,6 @@ The Arm Mbed OS codebase is organized into conceptual submodules to limit the sc
 1. Patches must land on master before being backported to one or more release branches.
 1. Feature development may happen in a separate branch, and brought to master when complete.
 1. The master branch and release branches must never be rewritten.
-1. All contributors must sign [the CLA](https://os.mbed.com/contributor_agreement).
 1. For incoming sources, the only acceptable licenses are:
     - MIT.
     - Apache.

--- a/docs/reference/contributing/guidelines/style.md
+++ b/docs/reference/contributing/guidelines/style.md
@@ -2,7 +2,7 @@
 
 The Arm Mbed OS codebase is hosted on GitHub, and you can submit new features or bug fixes. Please follow the [guidelines for GitHub pull requests](#guidelines-for-github-pull-requests) and the [coding style guide](#coding-style) in your submissions.
 
-<span class="tips">**Tip:** Please also read [workflow](/docs/development/reference/workflow.html) sections for a review of the process and legal requirements.</span>
+<span class="tips">**Tip:** Please also read the [workflow](/docs/development/reference/workflow.html) section for a review of the process and legal requirements.</span>
 
 ### Code acceptance
 

--- a/docs/reference/contributing/guidelines/style.md
+++ b/docs/reference/contributing/guidelines/style.md
@@ -2,11 +2,11 @@
 
 The Arm Mbed OS codebase is hosted on GitHub, and you can submit new features or bug fixes. Please follow the [guidelines for GitHub pull requests](#guidelines-for-github-pull-requests) and the [coding style guide](#coding-style) in your submissions.
 
-<span class="tips">**Tip:** Please also read the [CLA](/docs/development/reference/license.html) and [workflow](/docs/development/reference/workflow.html) sections for a review of the process and legal requirements.</span>
+<span class="tips">**Tip:** Please also read [workflow](/docs/development/reference/workflow.html) sections for a review of the process and legal requirements.</span>
 
 ### Code acceptance
 
-[After the CLA](/docs/development/reference/license.html) is in place and the code has gone through automated testing, developers will take a look and comment on the pull request. If all is well and acceptable, your code will be ready for merging into the central development branch.
+After the code has gone through automated testing, developers will take a look and comment on the pull request. If all is well and acceptable, your code will be ready for merging into the central development branch.
 
 ### Coding style
 

--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -8,7 +8,6 @@ The maintainers are a small group of Mbed OS engineers who are responsible for t
 
 Responsibilities:
 
-1. Check for CLA compliance.
 1. Ensure the relevant stakeholders review pull requests.
 1. Guide contributors both technically and procedurally.
 1. Run pull requests through the CI systems.
@@ -58,7 +57,7 @@ Pull requests on GitHub have to meet the following requirements to keep the code
 	1. Use the imperative mood in the subject line.
 	1. Wrap the body at 72 characters.
 	1. Use the body to explain _what_ and _why_ vs _how_.
-- Because we use GitHub and explicit CLAs, special commit tags that other projects may use, such as “Reviewed-by”, or “Signed-off-by”, are redundant and should be omitted. GitHub tracks who reviewed what and when, and our stack of signed CLAs shows us who has agreed to our development contribution agreement.
+- Because we use GitHub, special commit tags that other projects may use, such as “Reviewed-by”, or “Signed-off-by”, are redundant and should be omitted. GitHub tracks who reviewed what and when.
 - Prefixing your commit message with a domain is acceptable, and we recommend doing so when it makes sense. However, prefixing one's domain with the name of the repo is not useful. For example, making a commit entitled "mbed-drivers: Fix doppelwidget frobulation" to the `mbed-drivers` repo is not acceptable because it is already understood that the commit applies to `mbed-drivers`. Renaming the commit to "doppelwidget: Fix frobulation" would be better, if we presume that "doppelwidget" is a meaningful domain for changes, because it communicates that the change applies to the doppelwidget area of `mbed-drivers`.
 - All new features and enhancements require documentation, tests and user guides for us to accept them. Please link each pull request to all relevant documentation and test pull requests.
 - Avoid merging commmits. (Always rebase when possible.)


### PR DESCRIPTION
We use inbound-outbound license. This follows the latest update to the
documentation that removed CLA page.

My latest update missed these, I realized after reviewing public docs that these are still there

cc @ARMmbed/mbed-os-maintainers 