### PR TITLE
Updated mbed-cli install instructions to use 'pip' instead of 'setup.py'

### DIFF
--- a/docs/tools/CLI/cli-setup.md/cli-reqs.md
+++ b/docs/tools/CLI/cli-setup.md/cli-reqs.md
@@ -104,7 +104,7 @@ $ git clone https://github.com/ARMmbed/mbed-cli
 Once cloned, you can install Mbed CLI as a Python package:
 
 ```
-$ python setup.py install
+$ pip install -e ./mbed-cli
 ```
 
 On Linux or macOS, you may need to run with `sudo`.


### PR DESCRIPTION
Docs PR for the following change: https://github.com/ARMmbed/mbed-cli/commit/629d2a8088f30f5b69d5bb75d254ad530d3d0e4d#diff-04c6e90faac2675aa89e2176d2eec7d8

(This particular commit I accidentally committed directly into mbed-cli)

The switch is because `pip` handles dependencies much better than `setup.py`.
When the change was made, it was found that using `setup.py` was pulling versions of packages that weren't even released (aka pyOCD beta packages).