### PR TITLE
Move using APIs content to tutorials_intro.md

### DIFF
--- a/docs/tutorials/tutorials_intro.md
+++ b/docs/tutorials/tutorials_intro.md
@@ -1,6 +1,6 @@
 ## Arm Mbed tutorials
 
-The Arm Mbed ecosystem is expansive and offers many opportunities. In contrast to other sections of the documentation, which provide background reference material, this section provides instructions for specific tasks you may wish to perform. This section contains two formats of documentation: tutorials and examples. Tutorials include step-by-step guidance, and examples are code snippets you can modify.
+The Arm Mbed ecosystem is expansive and offers many opportunities. In contrast to other sections of the documentation, which provide background reference material, this section provides instructions for specific tasks you may wish to perform. This section contains two formats of documentation: tutorials and examples. Tutorials include step-by-step guidance, and examples are code snippets you can use a starting point for your application or as a reference on how to use a particular API.
 
 ### Getting started
 

--- a/docs/tutorials/tutorials_intro.md
+++ b/docs/tutorials/tutorials_intro.md
@@ -1,3 +1,26 @@
 ## Arm Mbed tutorials
 
-The Arm Mbed ecosystem is expansive and offers many opportunities. In contrast to other sections of the documentation, which provide background reference material, this section provides step-by-step instructions for specific tasks you may wish to perform. These include Blinky, our example application; applications that build on Blinky; and debugging tasks. There are also tutorials about using the Arm Mbed Online Compiler, optimizing memory and optimizing power.
+The Arm Mbed ecosystem is expansive and offers many opportunities. In contrast to other sections of the documentation, which provide background reference material, this section provides step-by-step instructions for specific tasks you may wish to perform.
+
+### Using the APIs
+
+This section contains step-by-step tutorials that show you how to perform specific tasks that use the Arm Mbed APIs.
+
+#### Connectivity
+
+- [TCP sockets](cellular-tcp-sockets.html).
+- [BLE](ble-tutorial.html).
+- [LoRa Network](LoRa-tutorial.html).
+
+___
+
+#### RTOS
+
+- [EventQueue](the-eventqueue-api.html).
+
+___
+
+#### Drivers
+
+- [Flow control using Ticker and Wait](application-flow-control.html).
+

--- a/docs/tutorials/tutorials_intro.md
+++ b/docs/tutorials/tutorials_intro.md
@@ -1,26 +1,180 @@
 ## Arm Mbed tutorials
 
-The Arm Mbed ecosystem is expansive and offers many opportunities. In contrast to other sections of the documentation, which provide background reference material, this section provides step-by-step instructions for specific tasks you may wish to perform.
+The Arm Mbed ecosystem is expansive and offers many opportunities. In contrast to other sections of the documentation, which provide background reference material, this section provides instructions for specific tasks you may wish to perform. This section contains two formats of documentation: tutorials and examples. Tutorials include step-by-step guidance, and examples are code snippets you can modify.
+
+### Getting started
+
+<table>
+<tbody>
+<tr>
+<td><a href="../tutorials/mbed-os-quick-start.html">Mbed OS quick start tutorial</a></td>
+</tr>
+<tr>
+<td><a href="https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-blinky">Blinky example</a></td>
+</tr>
+</tbody>
+</table>
 
 ### Using the APIs
 
-This section contains step-by-step tutorials that show you how to perform specific tasks that use the Arm Mbed APIs.
+These tutorials show you how to perform specific tasks that use the Arm Mbed APIs:
 
-#### Connectivity
+#### Using connectivity APIs
 
-- [TCP sockets](cellular-tcp-sockets.html).
-- [BLE](ble-tutorial.html).
-- [LoRa Network](LoRa-tutorial.html).
+<table>
+<tbody>
+<tr>
+<td><a href="cellular-tcp-sockets.html">TCP sockets tutorial</a></td>
+<td><a href="../apis/wi-fi.html#wi-fi-example">Wi-Fi example</a></td>
+<td><a href="../apis/batteryservice.html#batteryservice-example">BLE battery level example</a></td>
+<td><a href="https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-ble-LED">BLE LED example</a></td>
+<td><a href="https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-ble-GAPButton">Button count over GAP example</a></td>
+</tr>
+<tr>
+<td><a href="ble-tutorial.html">BLE tutorial</a></td>
+<td><a href="../apis/cellular-api.html#cellular-example-connection-establishment">Cellular example</a></td>  
+<td><a href="../apis/heartrateservice.html#heartrateservice-example">BLE heart rate example</a></td>
+<td><a href="https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-ble-Button">BLE service template example</a></td>
+</tr>
+<tr>
+<td><a href="ble-tutorial.html">LoRa tutorial</a></td>
+<td><a href="../apis/mesh-api.html#mesh-example">Mesh example</a></td>  
+<td><a href="https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-ble-Thermometer">BLE thermometer example</a></td>
+<td><a href="../apis/lorawan-api.html#lorawan-example">LoRaWAN example</a></td>
+</tr>
+<tr>
+<td><a href="../apis/socket.html#socket-example">Socket example</a></td>
+<td><a href="../apis/ibeacon.html#ibeacon-example">BLE ibeacon example</a></td>  
+<td><a href="https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-ble-LEDBlinker">BLE LED blinker example</a></td>
+<td><a href="https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-nfc-SmartPoster">NFC example</a></td>
+</tr>
+</tbody>
+</table>
 
-___
+#### Using RTOS APIs
 
-#### RTOS
+<table>
+<tbody>
+<tr>
+<td><a href="the-eventqueue-api.html">EventQueue tutorial</a></td>
+</tr>
+</tbody>
+</table>
 
-- [EventQueue](the-eventqueue-api.html).
+#### Using drivers APIs
 
-___
+<table>
+<tbody>
+<tr>
+<td><a href="application-flow-control.html">Flow control tutorial</a></td>
+</tr>
+</tbody>
+</table>
 
-#### Drivers
+#### Using security APIs
 
-- [Flow control using Ticker and Wait](application-flow-control.html).
+<table>
+<tbody>
+<tr>
+<td><a href="https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-benchmark">TLS benchmark example</a></td>
+<td><a href="https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-hashing">TLS hashing example</a></td>
+<td><a href="https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-authcrypt">TLS authenticated encryption example</a></td>
+</tr>
+<tr>
+<td><a href="https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-tls-tls-client">TLS client example</a></td>
+<td><a href="../apis/devicekey.html#devicekey-example">DeviceKey example</a></td>
+</tr>
+</tbody>
+</table>
 
+#### Using storage APIs
+
+<table>
+<tbody>
+<tr>
+<td><a href="../apis/filesystem.html#file-system-example">FileSystem example</a></td>
+<td><a href="../apis/nvstore.html#nvstore-example">NVStore example</a></td>
+</tr>
+<tr>
+<td><a href="../apis/blockdevice.html#blockdevice-example">BlockDevice example</a></td>
+</tr>
+</tbody>
+</table>
+
+### Serial communication
+
+These tutorials teach you to communicate with your development board, an essential part of programming and debugging:
+
+<table>
+<tbody>
+<tr>
+<td><a href="windows-serial-driver.html">Windows serial driver tutorial</a></td>
+</tr>
+<tr>
+<td><a href="serial-comm.html">Board to PC communication over USB tutorial</a></td>
+</tr>
+</tbody>
+</table>
+
+### Debugging
+
+These tutorials show you how to install, export a project to and start a debugging session with different IDEs.
+
+<table>
+<tbody>
+<tr>
+<td><a href="debugging.html">Troubleshooting common issues tutorial</a></td>
+<td><a href="debugging-using-printf-statements.html">Debugging using printf statements tutorial</a></td>
+<td><a href="visual-studio-code.html">Debugging using Visual Studio Code tutorial</a></td>
+</tr>
+<tr>
+<td><a href="analyzing-mbed-os-crash-dump.html">Analyzing Mbed OS crash dump tutorial</a></td>
+<td><a href="eclipse.html">Debugging using Eclipse tutorial</a></td>
+<td><a href="debug-microbit.html">Debugging the BBC micro:bit with pyOCD and GDB tutorial</a></td>
+</tr>
+<tr>
+<td><a href="compile-time-errors.html">Compile time errors tutorial</a></td>
+<td><a href="keil-uvision.html">Debugging using Keil uVision tutorial</a></td>
+<td><a href="../apis/error-handling.html#error-handling-example">Error handling example</a></td>
+</tr>
+</tbody>
+</table>
+
+### Bootloader
+
+<table>
+<tbody>
+<tr>
+<td><a href="bootloader.html">Creating and using a bootloader tutorial</a></td>
+</tr>
+<tr>
+<td><a href="https://os.mbed.com/teams/mbed-os-examples/code/mbed-os-example-bootloader">Bootloader example</a></td>
+</tr>
+</tbody>
+</table>
+
+### Optimizing
+
+<table>
+<tbody>
+<tr>
+<td><a href="optimizing.html">Memory optimizations tutorial</a></td>
+<td><a href="../apis/mbed-statistics.html#thread-statistics-example">Thread statistics example</a></td>
+<td><a href="../apis/mbed-statistics.html#cpu-usage-example">CPU usage example</a></td>
+</tr>
+<tr>
+<td><a href="../apis/mbed-statistics.html#system-information-example">System information example</a></td>
+<td><a href="../apis/mbed-statistics.html#cpu-statistics-example">CPU statistics example</a></td>
+</tr>
+</tbody>
+</table>
+
+### Migrating to Mbed OS 5
+
+<table>
+<tbody>
+<tr>
+<td><a href="migrating-to-mbed-os-5.html">Mbed OS 2 to 5 migration guide tutorial</a></td>
+</tr>
+</tbody>
+</table>


### PR DESCRIPTION
Move content about using the APIs to the tutorials overview page.