### PR TITLE
Move stats API docs to config format

### DIFF
--- a/docs/api/platform/MbedStats.md
+++ b/docs/api/platform/MbedStats.md
@@ -1,6 +1,6 @@
 ## Mbed statistics
 
-Mbed OS provides a set of functions that you can use to capture the memory and thread statistics at runtime. `mbed_stats.h` declares these functions. To enable all Mbed OS statistics, you must enable the following Mbed OS configuration option.
+Mbed OS provides a set of functions that you can use to capture the memory and thread statistics at runtime. `mbed_stats.h` declares these functions. To enable all Mbed OS platform statistics, you must enable the following Mbed OS configuration option.
 
 ```json
 {

--- a/docs/api/platform/MbedStats.md
+++ b/docs/api/platform/MbedStats.md
@@ -12,6 +12,8 @@ Mbed OS provides a set of functions that you can use to capture the memory and t
 }
 ```
 
+<span class="tips">**Tip:** See the documentation of the [Arm Mbed configuration system](../reference/configuration.html) for more details about `mbed_app.json`. </span>
+
 ### Memory statistics
 
 You can use memory statistics functions to capture heap use, cumulative stack use or stack use for each thread at runtime. To enable memory use monitoring, you must enable the following Mbed OS configuration options:

--- a/docs/api/platform/MbedStats.md
+++ b/docs/api/platform/MbedStats.md
@@ -1,27 +1,75 @@
 ## Mbed statistics
 
-Mbed OS provides a set of functions that you can use to capture the memory and thread statistics at runtime. `mbed_stats.h` declares these functions. To enable all Mbed OS statistics, you must build code with the `MBED_ALL_STATS_ENABLED` macro.
+Mbed OS provides a set of functions that you can use to capture the memory and thread statistics at runtime. `mbed_stats.h` declares these functions. To enable all Mbed OS statistics, you must enable the following Mbed OS configuration option.
+
+```json
+{
+    "target_overrides": {
+        "*": {
+            "platform.all-stats-enabled": true
+        }
+    }
+}
+```
 
 ### Memory statistics
 
-You can use memory statistics functions to capture heap usage, cumulative stack usage or stack usage per thread at runtime. To enable memory usage monitoring, you must build Mbed OS with the following macros:
+You can use memory statistics functions to capture heap usage, cumulative stack usage or stack usage per thread at runtime. To enable memory usage monitoring, you must enable the following Mbed OS configuration options.
 
-- `MBED_HEAP_STATS_ENABLED`.
-- `MBED_STACK_STATS_ENABLED`.
+```json
+{
+    "target_overrides": {
+        "*": {
+            "platform.heap-stats-enabled": true,
+            "platform.stack-stats-enabled": true
+        }
+    }
+}
+```
 
 <span class="notes">**Note:** Each `malloc` or `calloc` memory allocation call adds an overhead of 8 bytes when heap memory statistics are enabled.</span>
 
 ### Thread statistics
 
-You can use the thread statistics function `mbed_stats_thread_get_each` to capture the thread ID, state, priority, name and stack information for all active threads at runtime. To enable thread monitoring, you must build Mbed OS with the `MBED_THREAD_STATS_ENABLED` macro.
+You can use the thread statistics function `mbed_stats_thread_get_each` to capture the thread ID, state, priority, name and stack information for all active threads at runtime. To enable thread monitoring, you must enable the following Mbed OS configuration options.
+
+```json
+{
+    "target_overrides": {
+        "*": {
+            "platform.thread-stats-enabled": true,
+        }
+    }
+}
+```
 
 ### System information
 
-You can use the `mbed_stats_sys_get` function to get the CPU ID, compiler information and RAM and ROM memories on the target device. You must build Mbed OS with the `MBED_SYS_STATS_ENABLED` macro to enable fetching of system information.
+You can use the `mbed_stats_sys_get` function to get the CPU ID, compiler information and RAM and ROM memories on the target device. To enable system information fetching, you must enable the following Mbed OS configuration option.
+
+```json
+{
+    "target_overrides": {
+        "*": {
+            "platform.sys-stats-enabled": true
+        }
+    }
+}
+```
 
 ### CPU statistics
 
-You can use the `mbed_stats_cpu_get` function to get the uptime, idle time and sleep time information. Timing information available is cumulative since the system is on. You must build Mbed OS with the `MBED_CPU_STATS_ENABLED` macro to enable fetching of CPU information. Please note CPU statistics depend on the availability of the low power timer in the hardware.
+You can use the `mbed_stats_cpu_get` function to get the uptime, idle time and sleep time information. Timing information available is cumulative since the system is on. Please note CPU statistics depend on the availability of the low power timer in the hardware. To enable fetching of CPU information, you must enable the following Mbed OS configuration option.
+
+```json
+{
+    "target_overrides": {
+        "*": {
+            "platform.cpu-stats-enabled": true
+        }
+    }
+}
+```
 
 ### Mbed statistics function reference
 

--- a/docs/api/platform/MbedStats.md
+++ b/docs/api/platform/MbedStats.md
@@ -1,6 +1,6 @@
 ## Mbed statistics
 
-Mbed OS provides a set of functions that you can use to capture the memory and thread statistics at runtime. `mbed_stats.h` declares these functions. To enable all Mbed OS platform statistics, you must enable the following Mbed OS configuration option.
+Mbed OS provides a set of functions that you can use to capture the memory and thread statistics at runtime. `mbed_stats.h` declares these functions. To enable all Mbed OS platform statistics, you must enable the following Mbed OS configuration option:
 
 ```json
 {
@@ -14,7 +14,7 @@ Mbed OS provides a set of functions that you can use to capture the memory and t
 
 ### Memory statistics
 
-You can use memory statistics functions to capture heap usage, cumulative stack usage or stack usage per thread at runtime. To enable memory usage monitoring, you must enable the following Mbed OS configuration options.
+You can use memory statistics functions to capture heap use, cumulative stack use or stack use for each thread at runtime. To enable memory use monitoring, you must enable the following Mbed OS configuration options:
 
 ```json
 {
@@ -31,13 +31,13 @@ You can use memory statistics functions to capture heap usage, cumulative stack 
 
 ### Thread statistics
 
-You can use the thread statistics function `mbed_stats_thread_get_each` to capture the thread ID, state, priority, name and stack information for all active threads at runtime. To enable thread monitoring, you must enable the following Mbed OS configuration options.
+You can use the thread statistics function `mbed_stats_thread_get_each` to capture the thread ID, state, priority, name and stack information for all active threads at runtime. To enable thread monitoring, you must enable the following Mbed OS configuration options:
 
 ```json
 {
     "target_overrides": {
         "*": {
-            "platform.thread-stats-enabled": true,
+            "platform.thread-stats-enabled": true
         }
     }
 }
@@ -45,7 +45,7 @@ You can use the thread statistics function `mbed_stats_thread_get_each` to captu
 
 ### System information
 
-You can use the `mbed_stats_sys_get` function to get the CPU ID, compiler information and RAM and ROM memories on the target device. To enable system information fetching, you must enable the following Mbed OS configuration option.
+You can use the `mbed_stats_sys_get` function to get the CPU ID, compiler information and RAM and ROM memories on the target device. To enable system information fetching, you must enable the following Mbed OS configuration option:
 
 ```json
 {
@@ -59,7 +59,7 @@ You can use the `mbed_stats_sys_get` function to get the CPU ID, compiler inform
 
 ### CPU statistics
 
-You can use the `mbed_stats_cpu_get` function to get the uptime, idle time and sleep time information. Timing information available is cumulative since the system is on. Please note CPU statistics depend on the availability of the low power timer in the hardware. To enable fetching of CPU information, you must enable the following Mbed OS configuration option.
+You can use the `mbed_stats_cpu_get` function to get the uptime, idle time and sleep time information. Timing information available is cumulative because the system is on. Please note CPU statistics depend on the availability of the low power timer in the hardware. To enable fetching of CPU information, you must enable the following Mbed OS configuration option:
 
 ```json
 {


### PR DESCRIPTION
https://github.com/ARMmbed/mbed-os/pull/8761 was merged, good to go!

Replace enabling stats API with macros to using the official config system.

@deepikabhavnani will this be accurate? It sounded like there was some potential changes in the required PR linked above.