### PR TITLE
Socket constructors which call open are deprecated

### DIFF
--- a/docs/api/networksocket/TCPSocket.md
+++ b/docs/api/networksocket/TCPSocket.md
@@ -4,7 +4,7 @@
 
 The TCPSocket class provides the ability to send a stream of data over TCP. TCPSockets maintain a stateful connection that starts with the `connect` member function. After successfully connecting to a server, you can use the `send` and `recv` member functions to send and receive data (similar to writing or reading from a file).
 
-The constructor takes no parameters. To initialize the socket on a specified NetworkInterface you must call `open` method, which takes a NetworkStack pointer.
+The constructor takes no parameters. To initialize the socket on a specified NetworkInterface, you must call `open` method, which takes a NetworkStack pointer.
 
 ### Server socket
 

--- a/docs/api/networksocket/TCPSocket.md
+++ b/docs/api/networksocket/TCPSocket.md
@@ -4,7 +4,7 @@
 
 The TCPSocket class provides the ability to send a stream of data over TCP. TCPSockets maintain a stateful connection that starts with the `connect` member function. After successfully connecting to a server, you can use the `send` and `recv` member functions to send and receive data (similar to writing or reading from a file).
 
-The constructor takes in the NetworkStack pointer to open the socket on the specified NetworkInterface. If you do not pass in the constructor, then you must call `open` to initialize the socket.
+The constructor takes no parameters. To initialize the socket on a specified NetworkInterface you must call `open` method, which takes a NetworkStack pointer.
 
 ### Server socket
 

--- a/docs/api/networksocket/UDPSocket.md
+++ b/docs/api/networksocket/UDPSocket.md
@@ -4,7 +4,7 @@
 
 The UDPSocket class provides the ability to send packets of data over UDP, using the `sendto` and `recvfrom` member functions. Packets can be lost or arrive out of order, so we suggest using a [TCPSocket](/docs/development/apis/tcpsocket.html) when you require guaranteed delivery.
 
-The constructor takes no parameters. To initialize the socket on a specified NetworkInterface you must call `open` method, which takes a NetworkStack pointer.
+The constructor takes no parameters. To initialize the socket on a specified NetworkInterface, you must call `open` method, which takes a NetworkStack pointer.
 
 UDP is a connectionless protocol. This allows you to send and receive packets to and from any remote addresses. Therefore, `Socket::listen()` and `Socket::accept()` functions are not implemented on UDPSocket.
 

--- a/docs/api/networksocket/UDPSocket.md
+++ b/docs/api/networksocket/UDPSocket.md
@@ -4,7 +4,7 @@
 
 The UDPSocket class provides the ability to send packets of data over UDP, using the `sendto` and `recvfrom` member functions. Packets can be lost or arrive out of order, so we suggest using a [TCPSocket](/docs/development/apis/tcpsocket.html) when you require guaranteed delivery.
 
-The constructor takes in the NetworkStack pointer to open the socket on the specified NetworkInterface. If you do not pass in the constructor, then you must call `open` to initialize the socket.
+The constructor takes no parameters. To initialize the socket on a specified NetworkInterface you must call `open` method, which takes a NetworkStack pointer.
 
 UDP is a connectionless protocol. This allows you to send and receive packets to and from any remote addresses. Therefore, `Socket::listen()` and `Socket::accept()` functions are not implemented on UDPSocket.
 


### PR DESCRIPTION
Documentation update according to this code change: https://github.com/ARMmbed/mbed-os/pull/8794