### PR TITLE
Propose to change title of "Connectivity stack"

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -651,7 +651,7 @@
                 "sources": []
             },
             {
-                "title": "Connectivity stacks",
+                "title": "Networking",
                 "sources": [{
                         "type": "markdown",
                         "url": "https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/reference/technology/connectivity/connectivity.md"


### PR DESCRIPTION
Under the Reference book/Architecture, there is title "Connectivity stacks".

The term stack is usually referring to actual implementation of the protocol, but this part of the book actually talks a lot about the protocols themself.
Therefore I propose that we change the title to more generic term "Networking"

@CC: @AnotherButler @iriark01 