### PR TITLE
Revert quick-start-blinky references

### DIFF
--- a/docs/tutorials/quickstart/cli_code.md
+++ b/docs/tutorials/quickstart/cli_code.md
@@ -5,8 +5,8 @@
    From your command-line, import the example:
 
    ```console
-   $ mbed import https://github.com/ARMmbed/mbed-os-quick-start-blinky
-   $ cd mbed-os-quick-start-blinky
+   $ mbed import https://github.com/ARMmbed/mbed-os-example-blinky
+   $ cd mbed-os-example-blinky
    ```
 
 1. Compile and program your board:

--- a/docs/tutorials/quickstart/quick-start-cli-debug.md
+++ b/docs/tutorials/quickstart/quick-start-cli-debug.md
@@ -7,7 +7,7 @@ The easiest way to do basic debugging is to use the `printf` command in your cod
 
 For example, add `printf("Hello World!\n\r");` to the top of your main function, and then recompile the program and flash it to your device.
 
-<span class="notes">**Note:** Unless otherwise specified, `printf` defaults to a baud rate of `9600` on Mbed OS. The `mbed-os-quick-start-blinky` example runs at a baud rate of `115200`. You can view the [configuration options page](../reference/configuration.html) to learn more about how to configure OS-level options.</span><!--but the thing I should really do now is set a new baud rate in my terminal, right?-->
+<span class="notes">**Note:** Unless otherwise specified, `printf` defaults to a baud rate of `9600` on Mbed OS. The `mbed-os-example-blinky` example runs at a baud rate of `115200`. You can view the [configuration options page](../reference/configuration.html) to learn more about how to configure OS-level options.</span><!--but the thing I should really do now is set a new baud rate in my terminal, right?-->
 
 ### Exporting to a desktop IDE
 

--- a/docs/tutorials/quickstart/quick-start-compiler.md
+++ b/docs/tutorials/quickstart/quick-start-compiler.md
@@ -9,15 +9,15 @@
 
 1. Double click on the `MBED.HTML` file. This adds your Mbed board to the Online Compiler as a compilation target.
 
-<span class="images">![](https://s3-us-west-2.amazonaws.com/mbed-os-docs-images/add_to_compiler2.png)</span>
+<span class="images">![](https://s3-us-west-2.amazonaws.com/mbed-os-docs-images/add_to_compiler.png)</span>
 
 ### Importing the code
 
 Click the button below to automatically import the example into the Online Compiler.
 
-[![View Example](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-quick-start-blinky)](https://github.com/ARMmbed/mbed-os-quick-start-blinky/blob/master/main.cpp)
+[![View Example](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os-example-blinky)](https://github.com/ARMmbed/mbed-os-example-blinky/blob/master/main.cpp)
 
-Alternatively, you may select the import button on the top left hand side of the Online Compiler screen and copy the [example link](https://github.com/ARMmbed/mbed-os-quick-start-blinky) into the prompt.
+Alternatively, you may select the import button on the top left hand side of the Online Compiler screen and copy the [example link](https://github.com/ARMmbed/mbed-os-example-blinky) into the prompt.
 
 <span class="images">![](https://s3-us-west-2.amazonaws.com/mbed-os-docs-images/import_program.png)</span>
 
@@ -25,7 +25,7 @@ Alternatively, you may select the import button on the top left hand side of the
 
 1. Click **Compile**. Your browser downloads the program as an executable file.
 
-    <span class="images">![](https://s3-us-west-2.amazonaws.com/mbed-os-docs-images/online_compile_button2.png)</span>
+    <span class="images">![](https://s3-us-west-2.amazonaws.com/mbed-os-docs-images/online_compile_button.png)</span>
 
 1. Open the folder where the executable file was downloaded, and then click and drag (or copy and paste) the file to your Mbed board's USB device folder.
 

--- a/docs/tutorials/quickstart/quick-start-online-debug.md
+++ b/docs/tutorials/quickstart/quick-start-online-debug.md
@@ -6,7 +6,7 @@ The easiest way to do basic debugging is to use the `printf` command in your cod
 
 For example, add `printf("Hello World!\n\r");` to the top of your main function, and then recompile the program and flash it to your device.
 
-<span class="notes">**Note:** Unless otherwise specified, `printf` defaults to a baud rate of `9600` on Mbed OS. The `mbed-os-quick-start-blinky` example runs at a baud rate of `115200`. You can view the [configuration options page](../reference/configuration.html) to learn more about how to configure OS-level options.</span><!--but the thing I should really do now is set a new baud rate in my terminal, right?-->
+<span class="notes">**Note:** Unless otherwise specified, `printf` defaults to a baud rate of `9600` on Mbed OS. The `mbed-os-example-blinky` example runs at a baud rate of `115200`. You can view the [configuration options page](../reference/configuration.html) to learn more about how to configure OS-level options.</span><!--but the thing I should really do now is set a new baud rate in my terminal, right?-->
 
 To determine which communication port your board connects to:
 


### PR DESCRIPTION
New quick start is replacing old blinky URL, revert to original name. 

Pending:
~https://github.com/ARMmbed/mbed-os-example-blinky/pull/144~
Merged! Good to go.