### PR TITLE
Remove target=blank from the youtube links

### DIFF
--- a/docs/tutorials/debug/debug_with_printf.md
+++ b/docs/tutorials/debug/debug_with_printf.md
@@ -324,8 +324,8 @@ void xprintf(const char *format, ...)
 
 Windows:
 
-[![Debugging using printf() calls on Windows](https://s3-us-west-2.amazonaws.com/mbed-os-docs-images/printf4.png)](http://www.youtube.com/watch?v=jAMTXK9HjfU&feature=youtu.be&t=31s){:target="_blank"}
+[![Debugging using printf() calls on Windows](https://s3-us-west-2.amazonaws.com/mbed-os-docs-images/printf4.png)](http://www.youtube.com/watch?v=jAMTXK9HjfU&feature=youtu.be&t=31s)
 
 macOS:
 
-[![Debugging using printf() calls on macOS](https://s3-us-west-2.amazonaws.com/mbed-os-docs-images/printf5.png)](http://www.youtube.com/watch?v=IR8Di53AGSk&feature=youtu.be&t=34s){:target="_blank"}
+[![Debugging using printf() calls on macOS](https://s3-us-west-2.amazonaws.com/mbed-os-docs-images/printf5.png)](http://www.youtube.com/watch?v=IR8Di53AGSk&feature=youtu.be&t=34s)


### PR DESCRIPTION
For some reason the `{:target="_blank"}` markdown hints are getting
rendered literally on the page:

https://os.mbed.com/docs/v5.8/tutorials/debugging-using-printf-statements.html#video-tutorials

Perhaps this is a doc engine bug?  Remove them for now so they don't
show up on the page.