### PR TITLE
If creating new JSON file, must add the * wildcard 1st

### DIFF
--- a/docs/reference/configuration/configuration.md
+++ b/docs/reference/configuration/configuration.md
@@ -88,7 +88,7 @@ An application may have one `mbed_app.json` in the root of the application and m
 
 The configuration system allows a user to override any defined configuration parameter with a JSON object named `"target_overrides"`.
 
-The keys in the `"target_overrides"` section are the names of a target that the overrides apply to, or the special wildcard `*` that applies to all targets. The values within the `"target_overrides"` section are objects that map configuration parameters, as printed by `mbed compile --config`, to new values. See the example `"target_overrides"` section below.
+The keys in the `"target_overrides"` section are the names of a target that the overrides apply to, or the special wildcard `*` that applies to all targets. This `*` special key must be the 1st object in the section.  The values within the `"target_overrides"` section are objects that map configuration parameters, as printed by `mbed compile --config`, to new values. See the example `"target_overrides"` section below.
 
 ```JSON
 "target_overrides": {
@@ -276,5 +276,7 @@ The `mbed_app.json` above defines its own configuration parameter (`welcome_stri
 - When compiling for `NCS36510`, `app.welcome_string` is `"Hello!"`, `target.mac_addr_high` is `"0x11223344"` (from the `NCS36510` override) and `mylib.timer_period` is 100 (from the `*` override).
 - When compiling for `LPC1768`, `app.welcome_string` is `"Hello!"` and `mylib.timer_period` is 100 (also from the `*` override).
 - The final artifact (binary) is named `my-application.bin`, as specified by the `artifact_name` section.
+
+If the `*` special wildcard is used in the `"target_overrides"` section, it must always be the first object.
 
 It is an error for the application configuration to override an undefined configuration parameter.

--- a/docs/reference/configuration/configuration.md
+++ b/docs/reference/configuration/configuration.md
@@ -88,7 +88,7 @@ An application may have one `mbed_app.json` in the root of the application and m
 
 The configuration system allows a user to override any defined configuration parameter with a JSON object named `"target_overrides"`.
 
-The keys in the `"target_overrides"` section are the names of a target that the overrides apply to, or the special wildcard `*` that applies to all targets. This `*` special key must be the 1st object in the section.  The values within the `"target_overrides"` section are objects that map configuration parameters, as printed by `mbed compile --config`, to new values. See the example `"target_overrides"` section below.
+The keys in the `"target_overrides"` section are the names of a target that the overrides apply to, or the special wildcard `*` that applies to all targets. This `*` special key must be the first object in the section. The values within the `"target_overrides"` section are objects that map configuration parameters, as printed by `mbed compile --config`, to new values. See the example `"target_overrides"` section below.
 
 ```JSON
 "target_overrides": {


### PR DESCRIPTION
When doing OOB for 5.11 release, made the mistake of creating a JSON file completely from memory where the special wildcard "*" key appeared after my target overrride.
	"target_overrides": {
		"DISCO_L475VG_IOT01A":{
			"target.network-default-interface-type": "WIFI",	
},
		"*": {
			"target.network-default-interface-type": "ETHERNET"
		},
}
This was never going to do the intended, because the toolchain scans from the top for matches and the wildcard '*' thus overwrites. JSON dictionaries are not supposed to be ordering sensitive, but in the toolchain our dictionary is order-sensitive. So it must appear 1st!