### PR TITLE
Document how to turn MPU off at compile time

### DIFF
--- a/docs/api/platform/MpuManagement.md
+++ b/docs/api/platform/MpuManagement.md
@@ -13,6 +13,8 @@ Mbed OS handles MPU management automatically in the following situations:
 
 <span class="notes">**Note:** Memory protection should be transparent to most applications and libraries because Mbed OS handles it automatically for operations that need to disable MPU protections, such as flash programming. This is an advanced feature intended for use by advanced developers; it is not required.</span>
 
+<span class="notes">**Note:** The configuration value `platform.use-mpu` can be set to `false` to remove the MPU driver and save code space.</span>
+
 #### RAM execute lock
 
 After boot, execution from RAM is not allowed. Libraries requiring the ability to execute from RAM can enable this by acquiring the RAM execution lock. The RAM execution lock has a count associated with it, and you can lock it multiple times. Execution from RAM is disabled only when all components have unlocked it.

--- a/docs/reference/configuration/Platform.md
+++ b/docs/reference/configuration/Platform.md
@@ -8,10 +8,23 @@ The following is the complete list of platform configuration parameters, as gene
 Configuration parameters
 ------------------------
 
+Name: platform.all-stats-enabled
+    Description: Set to 1 to enable all platform stats. When enabled the functions mbed_stats_*_get returns non-zero data. See mbed_stats.h for more information
+    Defined by: library:platform
+    No value set
 Name: platform.cpu-stats-enabled
     Description: Set to 1 to enable cpu stats. When enabled the function mbed_stats_cpu_get returns non-zero data. See mbed_stats.h for more information
     Defined by: library:platform
     No value set
+Name: platform.crash-capture-enabled
+    Description: Enables crash context capture when the system enters a fatal error/crash.
+    Defined by: library:platform
+    No value set
+Name: platform.cthunk_count_max
+    Description: The maximum CThunk objects used at the same time. This must be greater than 0 and less 256
+    Defined by: library:platform
+    Macro name: MBED_CONF_PLATFORM_CTHUNK_COUNT_MAX
+    Value: 8 (set by library:platform)
 Name: platform.default-serial-baud-rate
     Description: Default baud rate for a Serial or RawSerial instance (if not specified in the constructor)
     Defined by: library:platform
@@ -25,7 +38,7 @@ Name: platform.error-decode-http-url-str
     Description: HTTP URL string for ARM Mbed-OS Error Decode microsite
     Defined by: library:platform
     Macro name: MBED_CONF_PLATFORM_ERROR_DECODE_HTTP_URL_STR
-    Value: "\nFor more info, visit: https:/\/armmbed.github.io/mbedos-error/?error=0x%08X" (set by library:platform)
+    Value: "\nFor more info, visit: https://armmbed.github.io/mbedos-error/?error=0x%08X" (set by library:platform)
 Name: platform.error-filename-capture-enabled
     Description: Enables capture of filename and line number as part of error context capture, this works only for debug and develop builds. On release builds, filename capture is always disabled
     Defined by: library:platform
@@ -39,6 +52,15 @@ Name: platform.error-hist-size
     Defined by: library:platform
     Macro name: MBED_CONF_PLATFORM_ERROR_HIST_SIZE
     Value: 4 (set by library:platform)
+Name: platform.error-reboot-max
+    Description: Maximum number of auto reboots permitted when an error happens.
+    Defined by: library:platform
+    Macro name: MBED_CONF_PLATFORM_ERROR_REBOOT_MAX
+    Value: 1 (set by library:platform)
+Name: platform.fatal-error-auto-reboot-enabled
+    Description: Setting this to true enables auto-reboot on a fatal error.
+    Defined by: library:platform
+    No value set
 Name: platform.force-non-copyable-error
     Description: Force compile time error when a NonCopyable object is copied
     Defined by: library:platform
@@ -94,4 +116,9 @@ Name: platform.thread-stats-enabled
     Description: Set to 1 to enable thread stats. When enabled the function mbed_stats_thread_get_each returns non-zero data. See mbed_stats.h for more information
     Defined by: library:platform
     No value set
+Name: platform.use-mpu
+    Description: Use the MPU if available to fault execution from RAM and writes to ROM. Can be disabled to reduce image size.
+    Defined by: library:platform
+    Macro name: MBED_CONF_PLATFORM_USE_MPU
+    Value: 1 (set by library:platform)
 ```


### PR DESCRIPTION
Add information to the MPU management page about using the config "platform.disable-mpu" to disable the MPU to save space. Also update the platform configs to include this new value.

This PR has a code dependency on:
https://github.com/ARMmbed/mbed-os/pull/9040