### PR TITLE
Fix 5.6 errors

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -9,7 +9,7 @@
             "title": "Overview",
             "intro": {"type": "markdown", "url": "https://github.com/ARMmbed/mbed-os-5-docs/blob/5.6/docs/introduction/introduction.md"},
             "sources": [
-              {"type": "markdown", "url": "https://github.com/ARMmbed/mbed_os_release_notes/blob/new_engine/Docs/release_process.md"},
+              {"type": "markdown", "url": "https://github.com/ARMmbed/mbed-os-5-docs/blob/5.11/docs/introduction/release_process.md"},
               {"type": "markdown", "url": "https://github.com/ARMmbed/mbed-os-5-docs/blob/5.6/docs/introduction/terms.md"}
             ]
           }

--- a/docs/reference/api/drivers/Serial.md
+++ b/docs/reference/api/drivers/Serial.md
@@ -37,12 +37,6 @@ Provide a serial pass-through between the PC and an external UART.
 
 [![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/Serial_ex_2/)](https://os.mbed.com/teams/mbed_example/code/Serial_ex_2/file/8d318218bac1/main.cpp)
 
-#### Example three
-
-Attach a function to call during the generation of serial interrupts. This function defaults to interrupt on an RX pin.
-
-[![View code](https://www.mbed.com/embed/?url=https://os.mbed.com/teams/mbed_example/code/Serial_ex_3/)](https://os.mbed.com/teams/mbed_example/code/Serial_ex_3/file/3b040f367dd8/main.cpp)
-
 ### Related content
 
 - <a href="/docs/v5.6/introduction/glossary.html" target="_blank">Serial</a> glossary entry.

--- a/docs/reference/contributing/storage/BlockDevice.md
+++ b/docs/reference/contributing/storage/BlockDevice.md
@@ -18,7 +18,7 @@ Block device for SD cards.
 
 Block device the heap backs for quick testing.
 
-[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/HeapBlockDevice.h)](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/HeapBlockDevice.h)
+[![View code](https://www.mbed.com/embed/?url=https://github.com/ARMmbed/mbed-os/blob/mbed-os-5.6/features/filesystem/bd/HeapBlockDevice.h)](https://github.com/ARMmbed/mbed-os/blob/mbed-os-5.6/features/filesystem/bd/HeapBlockDevice.h)
 
 #### Block Device NOR-based SPI example
 


### PR DESCRIPTION
- point to latest release process docs
- remove example, with no corresponding repo
- use 5.6 release header file