### PR TITLE
Add a comment about requesting specific reviewers

### DIFF
--- a/docs/reference/contributing/guidelines/workflow.md
+++ b/docs/reference/contributing/guidelines/workflow.md
@@ -180,7 +180,10 @@ If a pull request is idle for more than two weeks, it will be closed. The author
 
 #### Reviews
 
-All pull requests must be reviewed. The Arm Mbed CI bot determines the most suitable person to review the pull request and tags that person accordingly.
+All pull requests must be reviewed. The Arm Mbed CI bot determines the most suitable person to review the pull request (based on the files changed) and tags that person accordingly. Specific reviewers can be requested by the author by @ tagging those people/teams in the 'Reviewers' section of the pull request template.
+E.g.
+Reviewers 
+@personA @TeamB
 
 Github dismisses a reviewer's status after any change to the pull request commit history (such as adding a new commit or rebasing). Smaller changes, such as documentation edits or rebases on top of latest master, only require additional review by maintainers. Their approval is sufficient because a team assigned as a reviewer already approved the pull request.
 


### PR DESCRIPTION
Authors can request specific reviewers in addition to those automatically
assigned by the CI bot. The review section of the workflow has been
updated to document this.